### PR TITLE
[WIP] feat: add sync binaries and update workflows

### DIFF
--- a/.bin/get-docs
+++ b/.bin/get-docs
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Create a temporary directory
+TEMP_DIR=$(mktemp -d)
+
+# Clone the repository into the temporary directory
+git clone https://github.com/deepgram/content "$TEMP_DIR"
+
+# Copy files from /articles/en/guide to /fern/docs, preserving paths
+rsync -av "$TEMP_DIR/articles/en/guide/" /fern/docs/
+
+# Remove the temporary directory
+rm -rf "$TEMP_DIR"
+
+echo "Files copied successfully from /articles/en/guide to /fern/docs, preserving existing files and paths"

--- a/.bin/get-specs
+++ b/.bin/get-specs
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Create a temporary directory
+TEMP_DIR=$(mktemp -d)
+
+# Clone the repository into the temporary directory
+git clone https://github.com/deepgram/deepgram-api-specs "$TEMP_DIR"
+
+# Copy asyncapi.yml and openapi.yml files to /fern directory
+cp "$TEMP_DIR/asyncapi.yml" "$TEMP_DIR/openapi.yml" /fern/
+
+# Remove the temporary directory
+rm -rf "$TEMP_DIR"
+
+echo "Files asyncapi.yml and openapi.yml copied successfully to /fern"

--- a/.github/workflows/fern-check.yml
+++ b/.github/workflows/fern-check.yml
@@ -27,5 +27,11 @@ jobs:
       - name: Build the custom components
         run: npm --prefix custom-app run build
 
+      - name: Sync public docs
+        run: ./.bin/get-docs
+
+      - name: Sync public specs
+        run: ./.bin/get-specs
+
       - name: Check API is valid
         run: fern check

--- a/.github/workflows/java-sdk.yml
+++ b/.github/workflows/java-sdk.yml
@@ -15,11 +15,16 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup node
+      - name: Setup Node.js
         uses: actions/setup-node@v3
+        with:
+          node-version: "22"
 
       - name: Download Fern
         run: npm install -g fern-api
+
+      - name: Sync public specs
+        run: ./.bin/get-specs
 
       - name: Release SDK
         env:

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Build the custom components
         run: npm --prefix custom-app run build
 
+      - name: Sync public docs
+        run: ./.bin/get-docs
+
+      - name: Sync public specs
+        run: ./.bin/get-specs
+
       - name: Generate preview URL
         id: generate-docs
         env:

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,6 +1,61 @@
+# This workflow is designed to generate a preview of documentation when a pull request is opened.
+# Additionally, it can be triggered remotely from another repository using the `repository_dispatch` event.
+#
+# To enable remote triggering and commenting on the original repository's PR, follow these steps:
+#
+# 1. Modify the Workflow to Listen for `repository_dispatch`:
+#    - Add `repository_dispatch` to the `on` section of this workflow to allow it to be triggered remotely.
+#
+# 2. Create a Webhook in the Other Repository:
+#    - In the repository where the PR is opened, create a webhook that sends a `repository_dispatch` event to this repository.
+#    - This can be done using a GitHub Action in the other repository that triggers on `pull_request` and uses the `repository_dispatch` event.
+#
+# 3. Example Action in the Other Repository:
+#    - Set up a GitHub Action in the other repository to trigger the `repository_dispatch` event:
+#
+#    ```yaml
+#    name: Trigger Preview Docs
+#
+#    on:
+#      pull_request:
+#        types: [opened]
+#
+#    jobs:
+#      dispatch:
+#        runs-on: ubuntu-latest
+#        steps:
+#          - name: Trigger Preview Docs Workflow
+#            uses: peter-evans/repository-dispatch@v2
+#            with:
+#              token: ${{ secrets.GITHUB_TOKEN }}
+#              repository: your-username/your-repo-name  # Replace with the target repository
+#              event-type: preview-docs
+#    ```
+#
+# 4. Return the Preview URL to a Comment on the Other Repository:
+#    - Modify the existing step in your `preview-docs.yml` to send the preview URL back to the original repository.
+#    - Use a personal access token with appropriate permissions to comment on the PR in the other repository.
+#
+#    ```yaml
+#      - name: Comment URL in PR
+#        uses: thollander/actions-comment-pull-request@v2.4.3
+#        with:
+#          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}  # Use a personal access token
+#          repository: other-username/other-repo-name  # Replace with the original repository
+#          issue-number: ${{ github.event.client_payload.pull_request_number }}  # Pass the PR number from the dispatch event
+#          filePath: preview_url.txt
+#    ```
+#
+# 5. Set Up Secrets:
+#    - Ensure you have set up the necessary secrets (`PERSONAL_ACCESS_TOKEN`) in your repository settings to allow commenting on the other repository.
+#
+# By following these steps, you can trigger the `preview-docs` workflow remotely and return the generated preview URL as a comment on the PR in the other repository.
+
 name: Preview Docs
 
-on: pull_request
+on:
+  pull_request:
+  repository_dispatch:
 
 jobs:
   run:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Build the custom components
         run: npm --prefix custom-app run build
 
+      - name: Sync public docs
+        run: ./.bin/get-docs
+
+      - name: Sync public specs
+        run: ./.bin/get-specs
+
       - name: Publish Docs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}


### PR DESCRIPTION
Below describes how the workflow could work to trigger preview links when editing content in a content repository, or how we might build when content is merged.

> This workflow is designed to generate a preview of documentation when a pull request is opened.
> Additionally, it can be triggered remotely from another repository using the `repository_dispatch` event.
> 
> To enable remote triggering and commenting on the original repository's PR, follow these steps:
> 
> 1. Modify the Workflow to Listen for `repository_dispatch`:
>    - Add `repository_dispatch` to the `on` section of this workflow to allow it to be triggered remotely.
> 
> 2. Create a Webhook in the Other Repository:
>    - In the repository where the PR is opened, create a webhook that sends a `repository_dispatch` event to this repository.
>    - This can be done using a GitHub Action in the other repository that triggers on `pull_request` and uses the `repository_dispatch` event.
> 
> 3. Example Action in the Other Repository:
>    - Set up a GitHub Action in the other repository to trigger the `repository_dispatch` event:
> 
>    ```yaml
>    name: Trigger Preview Docs
> 
>    on:
>      pull_request:
>        types: [opened]
> 
>    jobs:
>      dispatch:
>        runs-on: ubuntu-latest
>        steps:
>          - name: Trigger Preview Docs Workflow
>            uses: peter-evans/repository-dispatch@v2
>            with:
>              token: ${{ secrets.GITHUB_TOKEN }}
>              repository: your-username/your-repo-name  # Replace with the target repository
>              event-type: preview-docs
>    ```
> 
> 4. Return the Preview URL to a Comment on the Other Repository:
>    - Modify the existing step in your `preview-docs.yml` to send the preview URL back to the original repository.
>    - Use a personal access token with appropriate permissions to comment on the PR in the other repository.
> 
>    ```yaml
>      - name: Comment URL in PR
>        uses: thollander/actions-comment-pull-request@v2.4.3
>        with:
>          repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}  # Use a personal access token
>          repository: other-username/other-repo-name  # Replace with the original repository
>          issue-number: ${{ github.event.client_payload.pull_request_number }}  # Pass the PR number from the dispatch event
>          filePath: preview_url.txt
>    ```
> 
> 5. Set Up Secrets:
>    - Ensure you have set up the necessary secrets (`PERSONAL_ACCESS_TOKEN`) in your repository settings to allow commenting on the other repository.
> 
> By following these steps, you can trigger the `preview-docs` workflow remotely and return the generated preview URL as a comment on the PR in the other repository.
> 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209544588054976