### PR TITLE
chore: fixes incorrect redirect

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -772,7 +772,7 @@ redirects:
   - source: /api-reference/usage
     destination: /reference/get-all-requests
   - source: /documentation
-    destination: /docs
+    destination: /home
   - source: /documentation/features
     destination: /docs/stt-pre-recorded-feature-overview
   - source: /documentation/features/callback


### PR DESCRIPTION
this redirect was causing issues with routes that contained `/documentation` only. in the case of the Marketing site using `https://developers.deepgram.com/documentation/` to point to our Docs site.

now all routes  that use`/documentation` will go to `/home`and this will load our docs home page

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209576954582841