### PR TITLE
Fixed link for smart formatting

### DIFF
--- a/fern/docs/maintaining.mdx
+++ b/fern/docs/maintaining.mdx
@@ -31,7 +31,7 @@ Your Deepgram Account Representative provides you with a list of several differe
 
 * Additional features you plan to use, including formatting, diarization, keywords, redaction, audio intelligence, etc.
 
-  * The use of [smart formatting](/doc/smart-formatting) in English depends on the Named Entity Recognition (NER) model.
+  * The use of [smart formatting](/doc/smart-format) in English depends on the Named Entity Recognition (NER) model.
   * Nova-3 introduces the native [Keyterms](/docs/keyterm) parameter which replaces the [Keywords](/docs/keywords) parameter used with other model architectures.
   * Nova-2 and other model archticture Keywords requires the `phoneme` and `g2p` models.
   * Sentiment analysis, intent recognition, and topic detection require the `sit` model.


### PR DESCRIPTION
Missed an error with the new smart-formatting link, this fixes it.