### PR TITLE
Corrected 'new' link for STT models page

### DIFF
--- a/fern/docs/maintaining.mdx
+++ b/fern/docs/maintaining.mdx
@@ -17,7 +17,7 @@ Deepgram model updates include releases of new architectures, features, and lang
 
 Your Deepgram Account Representative provides you with a list of several different models depending on your use cases. For selecting language models to download, consider:
 
-* Which [Speech-to-text (STT) Models](/docs/self-hosted-self-service-tutorial) and [Text-to-speech (TTS) Models](/docs/tts-models) you want to deploy.
+* Which [Speech-to-text (STT) Models](/docs/models-languages-overview) and [Text-to-speech (TTS) Models](/docs/tts-models) you want to deploy.
 
 * Language(s) you will transcribe. Each model file name contains a language code, such as `en` (English) or `es` (Spanish).
 


### PR DESCRIPTION
One of my new links for the STT models page was incorrect in the self-hosted maintenance page. This corrects that error.