### PR TITLE
[WIP] 🌿: prepare new frontend changes

### DIFF
--- a/fern/assets/component.js
+++ b/fern/assets/component.js
@@ -73,23 +73,15 @@ async function startAlgolia() {
   const indexName = "crawler_unified";
   const apiKey = "e50ef768d9ac1a2b80ac6101639df429";
 
-  const mobileSearch = document.createElement("span");
-  mobileSearch.id = "mobile-search";
+  const searchContainer = document.createElement("span");
+  searchContainer.style.flex = "1";
 
-  const desktopSearch = document.createElement("span");
-  desktopSearch.id = "desktop-search";
+  const fernSearchButton = document.getElementById("fern-search-button");
+  fernSearchButton.parentNode.insertBefore(searchContainer, fernSearchButton);
 
-  const fernMobileSearchButton = document.querySelector(".fern-header-right-menu #fern-search-button");
-  fernMobileSearchButton.parentNode.insertBefore(mobileSearch, fernMobileSearchButton);
+  fernSearchButton.remove();
 
-  const fernDesktopSearchButton = document.querySelector(".fern-header-searchbar #fern-search-button");
-  fernDesktopSearchButton.parentNode.insertBefore(desktopSearch, fernDesktopSearchButton);
-
-  fernMobileSearchButton.remove();
-  fernDesktopSearchButton.remove();
-
-  docsearch({ container: "#desktop-search", appId, indexName, apiKey });
-  docsearch({ container: "#mobile-search", appId, indexName, apiKey });
+  docsearch({ container: desktopSearch, appId, indexName, apiKey });
 }
 
 document.addEventListener("DOMContentLoaded", async () => {

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -183,7 +183,7 @@ a.fern-card.interactive[href*="playground.deepgram.com"] span.card-icon {
  * Deepgram Announcement Card
  */
 
-#announcement > .fern-card {
+#announcement .fern-card {
   --gradient: var(--dg-primary);
 
   background: var(--dg-fill) padding-box, var(--gradient) border-box;
@@ -193,15 +193,15 @@ a.fern-card.interactive[href*="playground.deepgram.com"] span.card-icon {
   transform: scale(0.8);
 }
 
-#announcement > .fern-card > div {
+#announcement .fern-card > div {
   justify-content: center;
 }
 
-#announcement > .fern-card > div > div {
+#announcement .fern-card > div > div {
   width: auto;
 }
 
-#announcement > .fern-card:hover {
+#announcement .fern-card:hover {
   background: var(--dg-fill) padding-box, var(--dg-primary-hover) border-box;
   transform: scale(0.81);
 }

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -190,7 +190,6 @@ a.fern-card.interactive[href*="playground.deepgram.com"] span.card-icon {
   border-radius: 1000px;
   border: 0.125rem solid transparent;
   padding: 0.5rem;
-  transform: scale(0.8);
 }
 
 #announcement .fern-card > div {
@@ -203,7 +202,7 @@ a.fern-card.interactive[href*="playground.deepgram.com"] span.card-icon {
 
 #announcement .fern-card:hover {
   background: var(--dg-fill) padding-box, var(--dg-primary-hover) border-box;
-  transform: scale(0.81);
+  transform: scale(1.01);
 }
 
 /**

--- a/fern/docs/landing.mdx
+++ b/fern/docs/landing.mdx
@@ -4,28 +4,7 @@ hide-toc: true
 layout: overview
 ---
 
-<style>
-{`
-  .fern-page-heading {
-    display: none;
-  }
-
-  #announcement + header {
-    text-align: center;
-    padding-top: 2rem;
-  }
-`}
-</style>
-
 <Markdown src="../snippets/announcement.mdx" />
-
-<header>
-  # Welcome to Deepgram's Docs!
-
-  Build your voice AI solutions with the best Voice Agent, Speech-to-Text, and Text-to-Speech APIs.
-
-  Enterprise grade APIs (cloud-hosted or self-hosted) with the highest accuracy, low latency, and lowest cost.
-</header>
 
 <CardGroup cols={1}>
   <Card title="Voice Agent" icon={<Icon icon="headset" color="var(--hl-meadow)" />}>


### PR DESCRIPTION
This PR implements necessary changes to prepare Deepgram's docs for Fern's frontend upgrade. 

Improvements include:
- improved color scales (grayscale and accent color scales are adjusted to more closely match the provided colors)
- more consistent styles across all markdown pages: content body is thinner for better reading experience, and border - radiuses around cards all adjusted to be uniform.
- spacing and border radius can now be adjusted using the --spacing and --radius css variables. You can now shrink the radius or make spacing around content tighter or wider to match your branding.
- better in-browser performance (less client-side javascript, and less HTML)
- bug-fixes for search—including support for mobile view
- improved sidebar (state is saved between tab navigation), and improved placement of sidebar menu in mobile view
- less content shift after navigation in most places (where this was buggy previously)
- deep linkable api explorer (by adding /~explorer at the end of urls)
- and more!

One note: icons can no longer be styled with linear gradients using CSS. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209696963460018