### PR TITLE
chore: Add type name overrides for long generated types.

### DIFF
--- a/fern/asyncapi-overrides.yml
+++ b/fern/asyncapi-overrides.yml
@@ -1,4 +1,45 @@
 channels:
+  agent:
+    messages:
+      settingsConfiguration:
+        payload:
+          properties:
+            audio:
+              x-fern-type-name: AudioConfig
+            agent:
+              x-fern-type-name: AgentConfig
+              properties:
+                listen:
+                  x-fern-type-name: AgentListenSettings
+                think:
+                  x-fern-type-name: AgentThinkSettings
+                  properties:
+                    provider:
+                      x-fern-type-name: ThinkProvider
+                    functions:
+                      items:
+                        x-fern-type-name: ThinkFunction
+                        properties:
+                          headers:
+                            items:
+                              x-fern-type-name: FunctionHeader
+                          method:
+                            x-fern-type-name: FunctionMethod
+                          parameters:
+                            x-fern-type-name: FunctionParameters
+                            properties:
+                              properties:
+                                x-fern-type-name: FunctionParameterProperties
+                                additionalProperties:
+                                  x-fern-type-name: FunctionParameterPropertiesAdditionalProperties
+                          url:
+                            x-fern-type-name: ThinkFunctionUrl
+                            
+                speak:
+                  x-fern-type-name: AgentSpeakSettings
+                  properties:
+                    provider:
+                      x-fern-type-name: SpeakProvider
   speak:
     # Sets API Playground parameters to optional
     parameters:

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -27,7 +27,7 @@ groups:
   ts-sdk:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.44.5
+        version: 0.49.3
         output:
           location: npm
           package-name: deepgram


### PR DESCRIPTION
This PR overrides the default TS type name generation to include more idiomatic types.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209815211181004