### PR TITLE
Fix typo in streaming tts docs

### DIFF
--- a/fern/docs/streaming-text-to-speech.mdx
+++ b/fern/docs/streaming-text-to-speech.mdx
@@ -131,8 +131,8 @@ Deepgram has several SDKs that can make the API easier to use. Follow these step
       _socket.send(json.dumps({"type": "Close"}))
       _socket.close()
 
-      _listen_thread.join()
-      _listen_thread = None
+      _receiver_thread.join()
+      _receiver_thread = None
 
   class Speaker:
       _audio: pyaudio.PyAudio


### PR DESCRIPTION
Found the issue when using this code sample locally - probably just forgot to rename the local variable when copy/pasting from the STT example?