### PR TITLE
feat: aura 2 docs updates REST Only

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -534,3 +534,34 @@ div[id="/reference/speech-to-text-api/listen#request"]
 .DocSearch-Logo {
   opacity: 0 !important;
 }
+
+/* Voice Model Table Styles */
+
+.voice-model-table {
+  width: clamp(808px, 60%, 1008px);
+  margin-inline: auto;
+  overflow-x: auto;
+}
+
+/* Audio player styles */
+.voice-model-table audio {
+  width: 100px;
+  height: 48px;
+}
+
+/* Audio player styles */
+.voice-model-table audio::-webkit-media-controls-panel {
+  background: linear-gradient(90deg, #333333 -91.5%, #717171 80.05%);
+  justify-content: center;
+  align-items: center;
+}
+
+/* Audio player styles */
+.voice-model-table audio::-webkit-media-controls-timeline,
+.voice-model-table audio::-webkit-media-controls-time-remaining-display,
+.voice-model-table audio::-webkit-media-controls-current-time-display,
+.voice-model-table audio::-webkit-media-controls-volume-slider,
+.voice-model-table audio::-webkit-media-controls-mute-button,
+.voice-model-table audio::-webkit-media-controls-toggle-closed-captions-button {
+  display: none;
+}

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -366,6 +366,8 @@ navigation:
             path: docs/tts-sample-rate.mdx
       - section: Tips and Tricks
         contents:
+          - page: Improving Aura-2 Formatting
+            path: docs/improving-aura-2-formatting.mdx
           - page: Handling Audio Issues in Text To Speech
             path: docs/handling-audio-issues-in-text-to-speech.mdx
           - page: Sending LLM Outputs to a WebSocket
@@ -554,9 +556,6 @@ navigation:
         contents:
           - page: Code of Conduct
             path: hidden-pages/code-of-conduct.mdx
-            hidden: true
-          - page: Aura 2 Formatting
-            path: hidden-pages/aura-2-formatting.mdx
             hidden: true
           - page: Aura 2 Private Preview
             path: hidden-pages/aura-2-preview.mdx

--- a/fern/docs/dotnet-sdk-streaming-text-to-speech.mdx
+++ b/fern/docs/dotnet-sdk-streaming-text-to-speech.mdx
@@ -4,6 +4,9 @@ subtitle: An overview of the Deepgram .NET SDK and Deepgram streaming text-to-sp
 slug: docs/dotnet-sdk-streaming-text-to-speech
 ---
 
+<Warning>
+Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
+</Warning>
 
 ## Installing the SDK
 
@@ -40,7 +43,7 @@ To begin using Deepgram's Text-to-Speech functionality, you need to install the 
           {
               // Initialize Library with default logging
               Library.Initialize();
-            
+
               // use the client factory with a API Key set with the "DEEPGRAM_API_KEY" environment variable
               var speakClient = ClientFactory.CreateSpeakWebSocketClient();
 

--- a/fern/docs/dotnet-sdk-text-to-speech.mdx
+++ b/fern/docs/dotnet-sdk-text-to-speech.mdx
@@ -4,7 +4,6 @@ subtitle: An overview of the Deepgram .NET SDK and Deepgram text-to-speech.
 slug: docs/dotnet-sdk-text-to-speech
 ---
 
-
 ## Installing the SDK
 
 To begin using Deepgram's Text-to-Speech functionality, you need to install the Deepgram .NET SDK in your existing project. You can do this using the following command:

--- a/fern/docs/dotnet-sdk-text-to-speech.mdx
+++ b/fern/docs/dotnet-sdk-text-to-speech.mdx
@@ -45,7 +45,7 @@ To begin using Deepgram's Text-to-Speech functionality, you need to install the 
                   "test.mp3",
                   new SpeakSchema()
                   {
-                      Model = "aura-asteria-en",
+                      Model = "aura-2-thalia-en",
                   });
 
               //Console.WriteLine(response);
@@ -88,7 +88,7 @@ Deepgram's TTS API allows you to start playing the audio as soon as the first by
                   new TextSource("Hello World!"),
                   new SpeakSchema()
                   {
-                      Model = "aura-asteria-en",
+                      Model = "aura-2-thalia-en",
                   });
 
               await foreach (var audioSegment in response.AudioStream)
@@ -128,14 +128,14 @@ Deepgram's TTS API allows you to start playing the audio as soon as the first by
             	// STEP 3: process the desired text in segments
               // Send each seqment to Deepgram to convert to Speech
               var segments = SegmentTextBySentence(inputText);
-            
+
               foreach (var segment in segments)
               {
                   var response = await deepgramClient.Stream(
                       new TextSource(segment),
                       new SpeakSchema()
                       {
-                          Model = "aura-asteria-en",
+                          Model = "aura-2-thalia-en",
                       });
 
                   await foreach (var audioSegment in response.AudioStream)

--- a/fern/docs/go-sdk-streaming-text-to-speech.mdx
+++ b/fern/docs/go-sdk-streaming-text-to-speech.mdx
@@ -4,6 +4,9 @@ subtitle: An overview of the Deepgram Go SDK and Deepgram streaming text-to-spee
 slug: docs/go-sdk-streaming-text-to-speech
 ---
 
+<Warning>
+Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
+</Warning>
 
 ## Installing the SDK
 

--- a/fern/docs/go-sdk-streaming-text-to-speech.mdx
+++ b/fern/docs/go-sdk-streaming-text-to-speech.mdx
@@ -260,7 +260,7 @@ To begin using Deepgram's Text-to-Speech functionality, you need to install the 
 
   	// set the TTS options
   	ttsOptions := &interfaces.WSSpeakOptions{
-  		Model:      "aura-2-thalia-en",
+  		Model:      "aura-asteria-en",
   		Encoding:   "linear16",
   		SampleRate: 48000,
   	}

--- a/fern/docs/go-sdk-streaming-text-to-speech.mdx
+++ b/fern/docs/go-sdk-streaming-text-to-speech.mdx
@@ -260,7 +260,7 @@ To begin using Deepgram's Text-to-Speech functionality, you need to install the 
 
   	// set the TTS options
   	ttsOptions := &interfaces.WSSpeakOptions{
-  		Model:      "aura-asteria-en",
+  		Model:      "aura-2-thalia-en",
   		Encoding:   "linear16",
   		SampleRate: 48000,
   	}

--- a/fern/docs/go-sdk-text-to-speech.mdx
+++ b/fern/docs/go-sdk-text-to-speech.mdx
@@ -51,7 +51,7 @@ To begin using Deepgram's Text-to-Speech functionality, you need to install the 
 
   	// set the Transcription options
   	options := &interfaces.SpeakOptions{
-  		Model: "aura-asteria-en",
+  		Model: "aura-2-thalia-en",
   	}
 
   	// create a Deepgram client
@@ -123,10 +123,10 @@ The following example demonstrates how to stream the audio as soon as the first 
     // By default, the DEEPGRAM_API_KEY environment variable will be used for the API Key
   	c := client.NewWithDefaults()
   	dg := speak.New(c)
-    
+
    	// STEP 3: Configure the options (such as model choice, audio configuration, etc.)
   	options := &interfaces.SpeakOptions{
-  		Model: "aura-asteria-en",
+  		Model: "aura-2-thalia-en",
   	}
 
     // STEP 4: send/process the desired text to Deepgram to convert to Speech
@@ -191,10 +191,10 @@ This example shows how to chunk the text source by sentence boundaries and strea
     // By default, the DEEPGRAM_API_KEY environment variable will be used for the API Key
   	c := client.NewWithDefaults()
   	dg := speak.New(c)
-    
+
    	// STEP 3: Configure the options (such as model choice, audio configuration, etc.)
   	options := &interfaces.SpeakOptions{
-  		Model: "aura-asteria-en",
+  		Model: "aura-2-thalia-en",
   	}
 
     // STEP 4: send/process the desired text to Deepgram to convert to Speech

--- a/fern/docs/improving-aura-2-formatting.mdx
+++ b/fern/docs/improving-aura-2-formatting.mdx
@@ -5,61 +5,69 @@ slug: docs/improving-aura-2-formatting
 description: "Formatting Text for Aura-2"
 ---
 
-Aura-2 is a context-aware text-to-speech (TTS) model that applies natural pacing, expressiveness, and fillers based on the context of the provided text. The quality of your text input directly impacts the naturalness of the audio output. This guide provides strategies for optimizing your text to get the most natural-sounding speech from Aura-2.
+Aura-2 is a context-aware text-to-speech (TTS) model that applies natural pacing, expressiveness, and fillers based on the context of the provided text. The quality of your text input directly impacts the naturalness of the audio output.
+
+This guide provides essential formatting techniques to optimize text for Aura-2 text-to-speech conversion. Following these guidelines will produce more natural-sounding speech output with appropriate pacing, intonation, and emphasis.
 
 <Info title="Note for LLM-Generated Text">
 If you are using a Large Language Model (LLM) to generate input text for Aura-2, you can prompt the LLM to provide conversational responses. For example, instruct the LLM to "respond in a natural, conversational tone with appropriate punctuation for text-to-speech" to get output that will sound more natural when processed by Aura-2.
 </Info>
 
-## Basic Formatting Principles
+## Core Principles
 
-* **Use proper sentence-ending punctuation.** Add periods at the end of sentences to create natural pauses. For example, write `Hello. One moment. I'm looking up your medical records.` instead of `Hello One Moment I'm looking up your medical records`.
+| Principle | Do This ✓ | Not This ✗ |
+|-----------|-----------|------------|
+| **End sentences with periods** | Hello. One moment. I'm looking up your records. | Hello One Moment I'm looking up your records |
+| **Use question marks for questions** | Would you like to add a drink for $1 more? | Would you like to add a drink for $1 more |
+| **Add exclamation points for enthusiasm** | Thanks for contacting our support team! | Thanks for contacting our support team |
+| **Use commas for natural pauses** | You can reach us by phone, chat, or email. | You can reach us by phone chat or email |
+| **Put command words in quotes** | Say "add item" to add more to your order. | Say add item to add more to your order |
 
-* **Use expressive punctuation for emotional tone.** Add exclamation points to convey enthusiasm or excitement. For example, write `Thanks for contacting our support team!` instead of `Thanks for contacting our support team.`
+## Natural Speech Patterns
 
-* **Always use question marks for questions.** This ensures proper rising intonation. For example, write `Would you like to add a drink to your order for $1 more?` instead of `Would you like to add a drink to your order for $1 more`.
+- **Direct address:** Include commas before names
+  - ✓ "Hello, Maria! We have a special offer today."
+  - ✗ "Hello Maria We have a special offer today"
 
-* **Add commas for natural breathing patterns.** Place commas strategically to create natural pauses. For example, write `You can reach us by phone, chat, or email during business hours.` instead of `You can reach us by phone chat or email during business hours.`
+- **Lists:** Insert commas between items
+  - ✓ "Would you like fries, a drink, or an apple pie?"
+  - ✗ "Would you like fries a drink or an apple pie"
 
-## Advanced Techniques
+- **Conversational flow:** Use short, standalone phrases
+  - ✓ "One moment. I'm searching for that information."
+  - ✗ Long combined sentences without pauses
 
-* **Use quotation marks for command words.** This helps emphasize specific phrases users should say. For example, write `Say "add item" to add more to your order, or say "checkout" to complete your purchase.` instead of `Say add item to add more to your order or say checkout to complete your purchase.`
+## Special Formatting
 
-* **Include commas before names in direct address.** This creates a natural greeting pause. For example, write `Hello, Maria! We have a special offer just for you today.` instead of `Hello Maria We have a special offer just for you today`.
+| Technique | Example |
+|-----------|---------|
+| **Hyphens for additional pauses** | Your total is $45.82 - please pull forward. |
+| **Clear step boundaries** | Please arrive early. Bring your insurance card - and medications. |
 
-* **Add commas in lists.** Insert commas between items in a list for natural pacing. For example, write `Would you like fries, a drink, or an apple pie with your meal?` instead of `Would you like fries a drink or an apple pie with your meal?`
+## Context Adaptation
 
-* **Use short, standalone phrases for a conversational feel.** Brief statements often sound more natural than forced complete sentences. For example, `One moment. I'm searching for that information.` creates a more natural flow than a longer combined sentence.
+- **Professional tone:** "We've processed your refund according to company policy."
+- **Casual tone:** "Good news! We've processed your refund - money should be back soon."
 
-## Special Formatting Instructions
+## Common Pitfalls
 
-* **Insert pauses with hyphens.** To create additional pauses in your text, insert "-" where you need the pause. For example, write `Your total comes to $45.82 - please pull forward to the next window.` instead of `Your total comes to $45.82 please pull forward to the next window.`
-
-## Context-Aware Formatting
-
-* **Adjust tone based on context.** Use different punctuation and phrasing depending on whether you need a professional or casual tone. For example, professional: `We've processed your refund according to company policy.` vs. casual: `Good news! We've processed your refund - the money should be back in your account soon.`
-
-* **Format instructions with clear boundaries.** Use periods and hyphens to separate different steps. For example, write `Please arrive 15 minutes early. Bring your insurance card - and a list of current medications.` instead of `Please arrive 15 minutes early bring your insurance card and a list of current medications.`
-
-## Common Pitfalls to Avoid
-
-1. **Missing punctuation** - Forces Aura-2 to guess at pacing and intonation
-2. **Run-on sentences** - Creates unnatural, breathless sounding speech
-3. **Inconsistent formatting** - Leads to unpredictable speech patterns
-4. **Abbreviations without context** - May be misinterpreted or mispronounced
-5. **Overuse of emphasis** - Too many exclamation points or capitalized words can sound unnatural
-6. **No space before question mark after URLs/emails** - Causes the question mark to be read as part of the address
-7. **Insufficient pauses in complex information** - Makes important details hard to comprehend
+- ❌ Missing punctuation
+- ❌ Run-on sentences
+- ❌ Inconsistent formatting
+- ❌ Unexplained abbreviations
+- ❌ Overusing emphasis (!!!, ALL CAPS)
+- ❌ No space before ? after URLs/emails
+- ❌ Insufficient pauses for complex information
 
 ## Testing Your Text
 
-Before implementing in production:
-
 1. Read your text aloud naturally
-2. Mark pauses where you naturally stop
-3. Ensure punctuation reflects these natural pauses
-4. Test variations with the Aura-2 model to find the most natural output
+2. Mark where you naturally pause
+3. Add punctuation to match these pauses
+4. Test variations with Aura-2 to find the most natural output
 
-## Conclusion
 
-The more natural your text input, the more natural Aura-2's speech output will be. By following these formatting guidelines, you can significantly improve the quality and naturalness of your text-to-speech implementations with Aura-2.
+**Remember:** Natural text input produces natural speech output. The formatting choices you make directly impact how Aura-2 interprets and vocalizes your content.
+
+---
+

--- a/fern/docs/improving-aura-2-formatting.mdx
+++ b/fern/docs/improving-aura-2-formatting.mdx
@@ -1,14 +1,9 @@
 ---
-title: "Formatting Text for Aura-2"
-slug: "aura-2-formatting"
+title: Improving Aura-2 Formatting
+subtitle: Optimize Aura-2 Text-to-Speech Generation Quality
+slug: docs/improving-aura-2-formatting
 description: "Formatting Text for Aura-2"
-hidden: true
 ---
-
-## Formatting Text for Aura-2
-# Tips and Tricks for Better Generation Quality with Aura-2
-
-## Introduction
 
 Aura-2 is a context-aware text-to-speech (TTS) model that applies natural pacing, expressiveness, and fillers based on the context of the provided text. The quality of your text input directly impacts the naturalness of the audio output. This guide provides strategies for optimizing your text to get the most natural-sounding speech from Aura-2.
 
@@ -26,8 +21,6 @@ If you are using a Large Language Model (LLM) to generate input text for Aura-2,
 
 * **Add commas for natural breathing patterns.** Place commas strategically to create natural pauses. For example, write `You can reach us by phone, chat, or email during business hours.` instead of `You can reach us by phone chat or email during business hours.`
 
-* **Use quotation marks for command words.** This helps emphasize specific phrases users should say. For example, write `Say "add item" to add more to your order.` instead of `Say add item to add more to your order.`
-
 ## Advanced Techniques
 
 * **Use quotation marks for command words.** This helps emphasize specific phrases users should say. For example, write `Say "add item" to add more to your order, or say "checkout" to complete your purchase.` instead of `Say add item to add more to your order or say checkout to complete your purchase.`
@@ -39,8 +32,6 @@ If you are using a Large Language Model (LLM) to generate input text for Aura-2,
 * **Use short, standalone phrases for a conversational feel.** Brief statements often sound more natural than forced complete sentences. For example, `One moment. I'm searching for that information.` creates a more natural flow than a longer combined sentence.
 
 ## Special Formatting Instructions
-
-* **Use a space between a URL or email and a question mark.** Otherwise, the question mark will be read out as part of the URL/email. For example, write `Can you send the email to developers@deepgram.com ?` instead of `Can you send the email to developers@deepgram.com?`.
 
 * **Insert pauses with hyphens.** To create additional pauses in your text, insert "-" where you need the pause. For example, write `Your total comes to $45.82 - please pull forward to the next window.` instead of `Your total comes to $45.82 please pull forward to the next window.`
 

--- a/fern/docs/improving-aura-2-formatting.mdx
+++ b/fern/docs/improving-aura-2-formatting.mdx
@@ -5,6 +5,10 @@ slug: docs/improving-aura-2-formatting
 description: "Formatting Text for Aura-2"
 ---
 
+<Warning>
+Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
+</Warning>
+
 Aura-2 is a context-aware text-to-speech (TTS) model that applies natural pacing, expressiveness, and fillers based on the context of the provided text. The quality of your text input directly impacts the naturalness of the audio output.
 
 This guide provides essential formatting techniques to optimize text for Aura-2 text-to-speech conversion. Following these guidelines will produce more natural-sounding speech output with appropriate pacing, intonation, and emphasis.

--- a/fern/docs/js-sdk-streaming-text-to-speech.mdx
+++ b/fern/docs/js-sdk-streaming-text-to-speech.mdx
@@ -6,6 +6,9 @@ subtitle: >-
 slug: docs/js-sdk-streaming-text-to-speech
 ---
 
+<Warning>
+Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
+</Warning>
 
 The Deepgram JavaScript SDK now works in both server and browser environments. A proxy configuration is required for browser environments (see the section below).
 

--- a/fern/docs/js-sdk-text-to-speech.mdx
+++ b/fern/docs/js-sdk-text-to-speech.mdx
@@ -42,7 +42,7 @@ Once the SDK is initialized, you can make a request to convert text into speech.
     const response = await deepgram.speak.request(
       { text },
       {
-        model: "aura-asteria-en",
+        model: "aura-2-thalia-en",
         encoding: "linear16",
         container: "wav",
       }
@@ -115,7 +115,7 @@ The following example demonstrates how to stream the audio as soon as the first 
     const response = await deepgram.speak.request(
       { text },
       {
-        model: 'aura-asteria-en',
+        model: 'aura-2-thalia-en',
         encoding: 'linear16',
         container: 'wav',
       }

--- a/fern/docs/python-sdk-streaming-text-to-speech.mdx
+++ b/fern/docs/python-sdk-streaming-text-to-speech.mdx
@@ -104,7 +104,7 @@ The Deepgram [`Speak Clients`](https://github.com/deepgram/deepgram-python-sdk/t
 
           # connect to websocket
           options = SpeakWSOptions(
-              model="aura-asteria-en",
+              model="aura-2-thalia-en",
               encoding="linear16",
               sample_rate=16000,
           )
@@ -211,7 +211,7 @@ The Deepgram [`Speak Clients`](https://github.com/deepgram/deepgram-python-sdk/t
 
           # connect to websocket
           options = SpeakWSOptions(
-              model="aura-asteria-en",
+              model="aura-2-thalia-en",
               encoding="linear16",
               sample_rate=16000,
           )

--- a/fern/docs/python-sdk-streaming-text-to-speech.mdx
+++ b/fern/docs/python-sdk-streaming-text-to-speech.mdx
@@ -4,6 +4,10 @@ subtitle: An overview of the Deepgram Python SDK and Deepgram streaming text-to-
 slug: docs/python-sdk-streaming-text-to-speech
 ---
 
+<Warning>
+Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
+</Warning>
+
 
 The Deepgram [`Speak Clients`](https://github.com/deepgram/deepgram-python-sdk/tree/main/deepgram/clients/speak/v1/websocket) allows you to generate human-like audio from text.
 

--- a/fern/docs/python-sdk-streaming-text-to-speech.mdx
+++ b/fern/docs/python-sdk-streaming-text-to-speech.mdx
@@ -104,7 +104,7 @@ The Deepgram [`Speak Clients`](https://github.com/deepgram/deepgram-python-sdk/t
 
           # connect to websocket
           options = SpeakWSOptions(
-              model="aura-2-thalia-en",
+              model="aura-asteria-en",
               encoding="linear16",
               sample_rate=16000,
           )
@@ -211,7 +211,7 @@ The Deepgram [`Speak Clients`](https://github.com/deepgram/deepgram-python-sdk/t
 
           # connect to websocket
           options = SpeakWSOptions(
-              model="aura-2-thalia-en",
+              model="aura-asteria-en",
               encoding="linear16",
               sample_rate=16000,
           )

--- a/fern/docs/python-sdk-text-to-speech.mdx
+++ b/fern/docs/python-sdk-text-to-speech.mdx
@@ -47,7 +47,7 @@ There are two functions provided to translate text-to-speech:
 
           # STEP 2: Configure the options (such as model choice, audio configuration, etc.)
           options = SpeakOptions(
-              model="aura-asteria-en",
+              model="aura-2-thalia-en",
           )
 
           # STEP 3: Call the save method on the speak property
@@ -76,7 +76,7 @@ There are two functions provided to translate text-to-speech:
 
           # STEP 2: Configure the options (such as model choice, audio configuration, etc.)
           options = SpeakOptions(
-              model="aura-asteria-en",
+              model="aura-2-thalia-en",
           )
 
           # STEP 3: Call the save method on the speak property
@@ -115,7 +115,7 @@ The following example demonstrates how to stream the audio as soon as the first 
 
   def synthesizeAudio(text):
       options = SpeakOptions(
-          model="aura-asteria-en",
+          model="aura-2-thalia-en",
       )
 
       response = deepgram.speak.rest.v("1").stream(filename, SPEAK_OPTIONS, options)
@@ -163,7 +163,7 @@ This example shows how to chunk the text source by sentence boundaries and strea
 
   def synthesizeAudio(text):
       options = SpeakOptions(
-          model="aura-asteria-en",
+          model="aura-2-thalia-en",
       )
 
       response = deepgram.speak.rest.v("1").stream(filename, SPEAK_OPTIONS, options)

--- a/fern/docs/send-llm-outputs-to-the-tts-web-socket.mdx
+++ b/fern/docs/send-llm-outputs-to-the-tts-web-socket.mdx
@@ -46,7 +46,7 @@ The code below demonstrates the simple use case of feeding simple text into the 
   RATE = 48000
   CHUNK = 8000
 
-  DEFAULT_URL = f"wss://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate={RATE}"
+  DEFAULT_URL = f"wss://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=linear16&sample_rate={RATE}"
   DEFAULT_TOKEN = os.environ.get("DEEPGRAM_API_KEY", None)
 
   def main():
@@ -216,7 +216,7 @@ The code below demonstrates using the OpenAI API to initiate a conversation with
   RATE = 48000
   CHUNK = 8000
 
-  DEFAULT_URL = f"wss://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate={RATE}"
+  DEFAULT_URL = f"wss://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=linear16&sample_rate={RATE}"
   DEFAULT_DEEPGRAM_TOKEN = os.environ.get("DEEPGRAM_API_KEY", None)
   DEFAULT_OPENAI_TOKEN = os.environ.get("OPENAI_API_KEY", None)
 
@@ -417,7 +417,7 @@ The code below demonstrates using the Anthropic API to initiate a conversation w
   CHUNK = 8000
 
   DEFAULT_URL = (
-      f"wss://api.beta.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate={RATE}"
+      f"wss://api.beta.deepgram.com/v1/speak?model=aura-asteria-en&encoding=linear16&sample_rate={RATE}"
   )
   DEFAULT_DEEPGRAM_TOKEN = os.environ.get("DEEPGRAM_API_KEY", None)
   DEFAULT_ANTHROPIC_TOKEN = os.environ.get("ANTHROPIC_API_KEY", None)

--- a/fern/docs/send-llm-outputs-to-the-tts-web-socket.mdx
+++ b/fern/docs/send-llm-outputs-to-the-tts-web-socket.mdx
@@ -46,7 +46,7 @@ The code below demonstrates the simple use case of feeding simple text into the 
   RATE = 48000
   CHUNK = 8000
 
-  DEFAULT_URL = f"wss://api.deepgram.com/v1/speak?encoding=linear16&sample_rate={RATE}"
+  DEFAULT_URL = f"wss://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate={RATE}"
   DEFAULT_TOKEN = os.environ.get("DEEPGRAM_API_KEY", None)
 
   def main():
@@ -187,7 +187,7 @@ The code below demonstrates the simple use case of feeding simple text into the 
 
   if __name__ == "__main__":
       main()
-      
+
   ```
 </CodeGroup>
 
@@ -216,7 +216,7 @@ The code below demonstrates using the OpenAI API to initiate a conversation with
   RATE = 48000
   CHUNK = 8000
 
-  DEFAULT_URL = f"wss://api.deepgram.com/v1/speak?encoding=linear16&sample_rate={RATE}"
+  DEFAULT_URL = f"wss://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate={RATE}"
   DEFAULT_DEEPGRAM_TOKEN = os.environ.get("DEEPGRAM_API_KEY", None)
   DEFAULT_OPENAI_TOKEN = os.environ.get("OPENAI_API_KEY", None)
 
@@ -417,7 +417,7 @@ The code below demonstrates using the Anthropic API to initiate a conversation w
   CHUNK = 8000
 
   DEFAULT_URL = (
-      f"wss://api.beta.deepgram.com/v1/speak?encoding=linear16&sample_rate={RATE}"
+      f"wss://api.beta.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate={RATE}"
   )
   DEFAULT_DEEPGRAM_TOKEN = os.environ.get("DEEPGRAM_API_KEY", None)
   DEFAULT_ANTHROPIC_TOKEN = os.environ.get("ANTHROPIC_API_KEY", None)

--- a/fern/docs/streaming-text-to-speech.mdx
+++ b/fern/docs/streaming-text-to-speech.mdx
@@ -232,7 +232,7 @@ Deepgram has several SDKs that can make the API easier to use. Follow these step
 
     const deepgram = createClient(process.env.DEEPGRAM_API_KEY);
 
-    const dgConnection = deepgram.speak.live({ model: "aura-asteria-en" });
+    const dgConnection = deepgram.speak.live({ model: "aura-2-thalia-en" });
 
     let audioBuffer = Buffer.alloc(0);
 
@@ -329,7 +329,7 @@ Deepgram has several SDKs that can make the API easier to use. Follow these step
 
           # connect to websocket
           options = SpeakWSOptions(
-              model="aura-asteria-en",
+              model="aura-2-thalia-en",
               encoding="linear16",
               sample_rate=16000,
           )
@@ -453,7 +453,7 @@ Deepgram has several SDKs that can make the API easier to use. Follow these step
 
   	// set the TTS options
   	ttsOptions := &interfaces.SpeakOptions{
-  		Model: "aura-asteria-en",
+  		Model: "aura-2-thalia-en",
   	}
 
   	// create the callback
@@ -647,7 +647,7 @@ Below is a high-level workflow for obtaining an audio stream from user-provided 
 
 ### Establish a WebSocket Connection
 
-To establish a connection, you must provide a few parameters on the URL to describe the type of audio you want. You can visit the API Ref (TODO: Link) to set the audio model, which controls the voice, the encoding, and the sample rate of the audio.
+To establish a connection, you must provide a few parameters on the URL to describe the type of audio you want. You can check out the [API Reference](/reference/text-to-speech-api/speak-streaming) to set the audio model, which controls the voice, the encoding, and the sample rate of the audio.
 
 ### Sending Text and Retrieving Audio
 
@@ -713,7 +713,15 @@ The maximum number of times you can send the [Flush message](/docs/tts-ws-flush)
 ### Rate Limits
 
 <Info>
-  The current rate limit per project for Pay As You Go is `40` concurrent connections and for Growth plans `80` concurrent connections. Learn more about [API Rate Limits](/reference/api-rate-limits).
+  For information on Deepgram's Concurrency Rate Limits, refer to our [API Rate Limits Documentation](/reference/api-rate-limits).
+</Info>
+
+#### Handling Rate Limits
+
+If the number of in-progress requests for a project meets or exceeds the rate limit, new requests will receive a **429: Too Many Requests** error.
+
+<Info>
+  For suggestions on handling Concurrency Rate Limits, refer to our [Working with Concurrency Rate Limits Documentation](/docs/working-with-concurrency-rate-limits) guide.
 </Info>
 
 ## What's Next?
@@ -728,10 +736,6 @@ Deepgram's features help you customize your request to produce the best output f
 * [Text Chunking for TTS Optimization](/docs/text-chunking-for-tts-optimization-copy)
 * [Sending LLM Outputs to the Websocket](/docs/send-llm-outputs-to-the-tts-web-socket)
 
-### Build your own End-to-End Deepgram Conversational Demo with Twilio
+### Starter Apps
 
-You can get started with building a simple conversational demo using Twilio and Deepgram streaming transcription and text-to-speech WebSockets by checking out our [Twilio Example with STT + TTS Streaming WS](/docs/build-voice-agent-with-twilio-deepgram-openai)
-
-<Info>
-  We'd love to get your feedback on Deepgram's Aura text-to-speech. You will receive $50 in additional console credits within two weeks after filling out the form, and you may be invited to join a group of users with access to the latest private releases. To fill out the form, [Click Here](https://deepgram.typeform.com/to/mcRYgKbd).
-</Info>
+* Clone and run one of our [Starter App](/docs/tts-starter-apps#text-to-speech-streaming) repositories to see a full application with a frontend UI and a backend server sending text to Deepgram to be converted into audio.

--- a/fern/docs/streaming-text-to-speech.mdx
+++ b/fern/docs/streaming-text-to-speech.mdx
@@ -9,6 +9,10 @@ slug: docs/streaming-text-to-speech
 
 <Markdown src="../snippets/tts-ws.mdx" />
 
+<Warning>
+Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
+</Warning>
+
 This guide will walk you through how to turn streaming text into speech with Deepgram's text-to-speech Websocket API.
 
 <Info>
@@ -232,7 +236,7 @@ Deepgram has several SDKs that can make the API easier to use. Follow these step
 
     const deepgram = createClient(process.env.DEEPGRAM_API_KEY);
 
-    const dgConnection = deepgram.speak.live({ model: "aura-2-thalia-en" });
+    const dgConnection = deepgram.speak.live({ model: "aura-asteria-en" });
 
     let audioBuffer = Buffer.alloc(0);
 
@@ -329,7 +333,7 @@ Deepgram has several SDKs that can make the API easier to use. Follow these step
 
           # connect to websocket
           options = SpeakWSOptions(
-              model="aura-2-thalia-en",
+              model="aura-asteria-en",
               encoding="linear16",
               sample_rate=16000,
           )
@@ -453,7 +457,7 @@ Deepgram has several SDKs that can make the API easier to use. Follow these step
 
   	// set the TTS options
   	ttsOptions := &interfaces.SpeakOptions{
-  		Model: "aura-2-thalia-en",
+  		Model: "aura-asteria-en",
   	}
 
   	// create the callback

--- a/fern/docs/streaming-text-to-speech.mdx
+++ b/fern/docs/streaming-text-to-speech.mdx
@@ -6,7 +6,6 @@ subtitle: >-
 slug: docs/streaming-text-to-speech
 ---
 
-
 <Markdown src="../snippets/tts-ws.mdx" />
 
 <Warning>

--- a/fern/docs/streaming-the-audio-output.mdx
+++ b/fern/docs/streaming-the-audio-output.mdx
@@ -31,7 +31,7 @@ The following two examples demonstrate how to play the audio as soon as the firs
   ```python Python
   import requests
 
-  DEEPGRAM_URL = "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+  DEEPGRAM_URL = "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   DEEPGRAM_API_KEY = "DEEPGRAM_API_KEY"
 
   payload = {
@@ -58,7 +58,7 @@ The following two examples demonstrate how to play the audio as soon as the firs
   const fs = require("fs");
   const https = require("https");
 
-  const DEEPGRAM_URL = "https://api.deepgram.com/v1/speak?model=aura-asteria-en";
+  const DEEPGRAM_URL = "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en";
   const DEEPGRAM_API_KEY = "DEEPGRAM_API_KEY";
 
   const payload = JSON.stringify({
@@ -108,7 +108,7 @@ The following two examples demonstrate how to play the audio as soon as the firs
   )
 
   const (
-  	deepgramURL    = "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+  	deepgramURL    = "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   	deepgramAPIKey = "DEEPGRAM_API_KEY"
   	textPayload    = `{"text": "Hello, how can I help you today? My name is Emily and I'm very glad to meet you. What do you think of this new text-to-speech API?"}`
   	outputFilename = "output.mp3"
@@ -159,7 +159,7 @@ The following two examples demonstrate how to play the audio as soon as the firs
   import re
   import requests
 
-  DEEPGRAM_URL = 'https://api.deepgram.com/v1/speak?model=aura-helios-en'
+  DEEPGRAM_URL = 'https://api.deepgram.com/v1/speak?model=aura-2-thalia-en'
   headers = {
       "Authorization": "Token DEEPGRAM_API_KEY",
       "Content-Type": "application/json"
@@ -170,7 +170,7 @@ The following two examples demonstrate how to play the audio as soon as the firs
   def segment_text_by_sentence(text):
       sentence_boundaries = re.finditer(r'(?<=[.!?])\s+', text)
       boundaries_indices = [boundary.start() for boundary in sentence_boundaries]
-      
+
       segments = []
       start = 0
       for boundary_index in boundaries_indices:
@@ -205,7 +205,7 @@ The following two examples demonstrate how to play the audio as soon as the firs
   const https = require("https");
   const fs = require("fs");
 
-  const DEEPGRAM_URL = "https://api.deepgram.com/v1/speak?model=aura-helios-en";
+  const DEEPGRAM_URL = "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en";
   const DEEPGRAM_API_KEY = "DEEPGRAM_API_KEY";
   const inputText =
     "Our story begins in a peaceful woodland kingdom where a lively squirrel named Frolic made his abode high up within a cedar tree's embrace. He was not a usual woodland creature, for he was blessed with an insatiable curiosity and a heart for adventure. Nearby, a glistening river snaked through the landscape, home to a wonder named Splash - a silver-scaled flying fish whose ability to break free from his water-haven intrigued the woodland onlookers. This magical world moved on a rhythm of its own until an unforeseen circumstance brought Frolic and Splash together. One radiant morning, while Frolic was on his regular excursion, and Splash was making his aerial tours, an unpredictable wave playfully tossed and misplaced Splash onto the riverbank. Despite his initial astonishment, Frolic hurriedly and kindly assisted his new friend back to his watery abode. Touched by Frolic's compassion, Splash expressed his gratitude by inviting his friend to share his world. As Splash perched on Frolic's back, he tasted of the forest's bounty, felt the sun’s rays filter through the colors of the trees, experienced the conversations amidst the woods, and while at it, taught the woodland how to blur the lines between earth and water.";
@@ -283,7 +283,7 @@ The following two examples demonstrate how to play the audio as soon as the firs
   )
 
   const (
-  	DeepgramURL    = "https://api.deepgram.com/v1/speak?model=aura-helios-en"
+  	DeepgramURL    = "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   	DeepgramApiKey = "DEEPGRAM_API_KEY"
   	InputText      = "Our story begins in a peaceful woodland kingdom where a lively squirrel named Frolic made his abode high up within a cedar tree's embrace. He was not a usual woodland creature, for he was blessed with an insatiable curiosity and a heart for adventure. Nearby, a glistening river snaked through the landscape, home to a wonder named Splash - a silver-scaled flying fish whose ability to break free from his water-haven intrigued the woodland onlookers. This magical world moved on a rhythm of its own until an unforeseen circumstance brought Frolic and Splash together. One radiant morning, while Frolic was on his regular excursion, and Splash was making his aerial tours, an unpredictable wave playfully tossed and misplaced Splash onto the riverbank. Despite his initial astonishment, Frolic hurriedly and kindly assisted his new friend back to his watery abode. Touched by Frolic's compassion, Splash expressed his gratitude by inviting his friend to share his world. As Splash perched on Frolic's back, he tasted of the forest's bounty, felt the sun’s rays filter through the colors of the trees, experienced the conversations amidst the woods, and while at it, taught the woodland how to blur the lines between earth and water."
   	OutputFile     = "output.mp3"

--- a/fern/docs/text-chunking-for-tts-optimization.mdx
+++ b/fern/docs/text-chunking-for-tts-optimization.mdx
@@ -56,19 +56,19 @@ This is a straightforward example which does not take into consideration charact
 
           # Choose a model to use for synthesis
           options = SpeakOptions(
-              model="aura-helios-en",
+              model="aura-2-thalia-en",
           )
 
           # Chunk the text into smaller parts
           text_chunks = chunk_text(input_text, MAX_CHUNK_SIZE)
-          
+
           # Synthesize audio for each chunk
           for i, chunk in enumerate(text_chunks):
               print(f"\nProcessing chunk {i + 1}...{chunk}\n")
               filename = f"chunk_{i + 1}.mp3"
 
               SPEAK_OPTIONS = {"text": chunk}
-          
+
               response = deepgram.speak.v("1").save(filename, SPEAK_OPTIONS, options)
               print(response.to_json(indent=4))
 
@@ -125,19 +125,19 @@ These are two grammatical rules for identifying clauses, but you may decide to i
 
           # Choose a model to use for synthesis
           options = SpeakOptions(
-              model="aura-helios-en",
+              model="aura-2-thalia-en",
           )
 
           # Chunk the text into smaller parts
           text_chunks = chunk_text_by_clause(input_text)
-          
+
           # Synthesize audio for each chunk
           for i, chunk in enumerate(text_chunks):
               print(f"\nProcessing chunk {i + 1}...{chunk}\n")
               filename = f"chunk_{i + 1}.mp3"
 
               SPEAK_OPTIONS = {"text": chunk}
-          
+
               response = deepgram.speak.v("1").save(filename, SPEAK_OPTIONS, options)
               print(response.to_json(indent=4))
 
@@ -211,19 +211,19 @@ This next example implements a more flexible chunking strategy that adjusts chun
 
           # Choose a model to use for synthesis
           options = SpeakOptions(
-              model="aura-helios-en",
+              model="aura-2-thalia-en",
           )
 
           # Chunk the text into smaller parts
           text_chunks = chunk_text_dynamically(input_text)
-          
+
           # Synthesize audio for each chunk
           for i, chunk in enumerate(text_chunks):
               print(f"\nProcessing chunk {i + 1}...{chunk}\n")
               filename = f"chunk_{i + 1}.mp3"
 
               SPEAK_OPTIONS = {"text": chunk}
-          
+
               response = deepgram.speak.v("1").save(filename, SPEAK_OPTIONS, options)
               # print(response.to_json(indent=4))
 
@@ -273,7 +273,7 @@ In this example, the text is chunked by sentence boundaries. Then each chunk is 
       deepgram = DeepgramClient(api_key="DEEPGRAM_API_KEY")
       # Choose a model to use for synthesis
       options = SpeakOptions(
-              model="aura-helios-en",
+              model="aura-2-thalia-en",
           )
       speak_options = {"text": text}
       # Synthesize audio and stream the response
@@ -308,9 +308,9 @@ In this example, the text is chunked by sentence boundaries. Then each chunk is 
 
 When using text chunking as a strategy to minimize latency, some factors to keep in mind are the following:
 
-* preserving naturalness of speech - Maintain proper pronunciation, intonation, and rhythm to enhance the user experience.
-* contextual understanding - Analyze the structure and meaning of the text to identify natural breakpoints, such as sentence or clause boundaries, for dividing the text.
-* dynamic chunking - Implement a flexible chunking strategy that adjusts chunk sizes dynamically based on the length and structure of the input text.
-* user expectations - Consider the preferences and needs of users, such as their tolerance for latency, the desired quality of synthesized speech, and their overall satisfaction with the application's performance.
+* Preserving naturalness of speech - Maintain proper pronunciation, intonation, and rhythm to enhance the user experience.
+* Contextual understanding - Analyze the structure and meaning of the text to identify natural breakpoints, such as sentence or clause boundaries, for dividing the text.
+* Dynamic chunking - Implement a flexible chunking strategy that adjusts chunk sizes dynamically based on the length and structure of the input text.
+* User expectations - Consider the preferences and needs of users, such as their tolerance for latency, the desired quality of synthesized speech, and their overall satisfaction with the application's performance.
 
 ***

--- a/fern/docs/text-chunking-for-tts-streaming-optimization.mdx
+++ b/fern/docs/text-chunking-for-tts-streaming-optimization.mdx
@@ -56,7 +56,7 @@ In most cases, the example below represents a simple example of taking a TTS aud
 
           # connect to websocket
           options = SpeakOptions(
-              model="aura-asteria-en",
+              model="aura-2-thalia-en",
               encoding="linear16",
               sample_rate=48000,
           )
@@ -77,7 +77,7 @@ In most cases, the example below represents a simple example of taking a TTS aud
           dg_connection.finish()
 
           print("Finished")
-          
+
       except Exception as e:
           print(f"An unexpected error occurred: {e}")
 

--- a/fern/docs/text-to-speech-latency.mdx
+++ b/fern/docs/text-to-speech-latency.mdx
@@ -32,11 +32,11 @@ Run the following CURL command to measure the total latency it takes to make a c
   -w "dns_resolution: %{time_namelookup}, tcp_established: %{time_connect}, ssl_handshake_done: %{time_appconnect}, TTFB: %{time_starttransfer}\n" \
   -X POST \
   -d "Welcome to Deepgram! We offer essential building blocks for voice AI." \
-  "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+  "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
-In the output you can see information about the total latency, as well as its subcomponents. In this example, the total latency is 745 milliseconds.
+In the output you can see information about the total latency, as well as its sub-components. In this example, the total latency is 745 milliseconds.
 
 <CodeGroup>
   ```bash output
@@ -85,7 +85,7 @@ Leverage the streaming output by playing audio immediately upon receiving the fi
 
 <CodeGroup>
   ```python Python
-  with requests.post("https://api.deepgram.com/v1/speak", stream=True, headers=headers, json={"text": "Hello world!"}) as r:
+  with requests.post("https://api.deepgram.com/v1/speak?model=aura-2-thalia-en", stream=True, headers=headers, json={"text": "Hello world!"}) as r:
       for chunk in r.iter_content(chunk_size=1024):
           if chunk:
               stream.write(chunk)
@@ -95,7 +95,7 @@ Leverage the streaming output by playing audio immediately upon receiving the fi
 You can begin streaming after receiving the first byte of audio because Deepgram's speed-up factor is high, far greater than the speed-up factor of 1x required to stream the output in real time.
 
 <Info>
-  **Tip:** Stream the audio output after receiving the first byte. Read the guide [Streaming Audio Outputs](/docs/streaming-the-audio-output) to learn more.
+  Stream the audio output after receiving the first byte. Read the guide [Streaming Audio Outputs](/docs/streaming-the-audio-output) to learn more.
 </Info>
 
 ### Audio Synthesis Latency
@@ -106,7 +106,7 @@ If you wait for the entire audio file to be returned to you before playing it, y
 
 <CodeGroup>
   ```python Python
-  response = requests.post("https://api.deepgram.com/v1/speak", headers=headers, json={"text": "Hello world!"})
+  response = requests.post("https://api.deepgram.com/v1/speak?model=aura-2-thalia-en", headers=headers, json={"text": "Hello world!"})
 
   if response.status_code == 200:
       data = response.content
@@ -137,7 +137,7 @@ The configuration and location of servers can greatly impact latency. Optimal se
 Consider optimizing server deployment by strategically locating them closer to your target audience, investing in high-performance hardware tailored to workload demands, and implementing load balancing mechanisms to evenly distribute incoming requests, thereby minimizing latency and ensuring consistent performance.
 
 <Info>
-  **Tip:** Maximize server performance and reduce latency by strategically placing servers near your target audience, investing in high-performance hardware, and implementing efficient load balancing techniques.
+  Maximize server performance and reduce latency by strategically placing servers near your target audience, investing in high-performance hardware, and implementing efficient load balancing techniques.
 </Info>
 
 ### Length of Text Input
@@ -150,14 +150,14 @@ Deepgram TTS accepts up to 2000 characters of text input. There is a baseline le
   ```
 </CodeGroup>
 
-Imagine a 300 character input. The latency could be estimated as: `600 + 40 * 3 = 720 ms`.
+Consider a 300 character input. The latency could be estimated as: `600 + 40 * 3 = 720 ms`.
 
-Then imagine tripling that to a 900-character input. The latency estimate is `600 + 40 * 9 = 960 ms`.
+Then consider tripling that to a 900-character input. The latency estimate is `600 + 40 * 9 = 960 ms`.
 
 Note that while the 900-character request is slower than the 300-character request, it takes 1.33x time to process 3x characters. Keep that in mind for longer-form content: for lowest cumulative latency across multiple requests, include as close to the max of 2000 characters in each request if you are chunking your text to fit Deepgram's input character limit.
 
 <Info>
-  **Tip:** For optimal latency across multiple requests, aim to include as close to the maximum of 2000 characters in each request when chunking your text to fit input character limits.
+  For optimal latency across multiple requests, aim to include as close to the maximum of 2000 characters in each request when chunking your text to fit input character limits.
 </Info>
 
 You can also run timing experiments yourself via CURL by modifying the number of characters in your text input:
@@ -173,7 +173,7 @@ You can also run timing experiments yourself via CURL by modifying the number of
   -H 'content-type: text/plain' \
   -X POST \
   -d "Frolic, a sprightly squirrel, stumbles onto Splash, a unique flying fish tangled on the riverbank. As diverse fellows, they traverse each other’s worlds. Splash, on land, savors forest fruits while Frolic, underwater, discovers vivid coral reefs. Their journey forms a profound bond." \
-  "https://api.deepgram.com/v1/speak"
+  "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -201,7 +201,7 @@ You can also run timing experiments yourself via CURL by modifying the number of
   -H 'content-type: text/plain' \
   -X POST \
   -d "In a serene woodland, Frolic, an adventurous squirrel, crosses paths with Splash, a flying fish marooned by a misjudged wave on the riverbank. Using his wits, Frolic helps his new friend back into the river. As a token of thanks, Splash offers Frolic an unusual proposition – a tour of each other's world. First, Splash rides on Frolic's back, savoring forest fruits and learning about rustling leaves. Then, with the help of a magical Splash-provided air bubble, Frolic dives underwater, opening gateways to vibrant coral reefs, mysterious underwater cave systems, and friendly aquatic creatures. This extraordinary journey shapes a deep-seated comradeship between the unlikeliest of friends, illuminating the joy of shared experiences and breaking down their comfort zones' barriers." \
-  "https://api.deepgram.com/v1/speak"
+  "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -220,7 +220,7 @@ You can also run timing experiments yourself via CURL by modifying the number of
 You will notice variation in latency; these numbers are an illustration of general trends and concepts, not a fixed result.
 
 <Info>
-  **Tip:** On long content, provide the maximum number of characters per request.
+On long content, provide the maximum number of characters per request.
 </Info>
 
 ### Audio Output Formats
@@ -232,7 +232,7 @@ Consider `linear16` encoded `wav` audio when prioritizing high-fidelity audio qu
 Choose compressed formats like `mp3` or `opus` when file size and bandwidth efficiency are critical factors. These formats offer reduced file sizes while maintaining acceptable audio quality, potentially reducing latency in streaming and transmission.
 
 <Info>
-  **Tip:** Choose the audio format that best suits your specific use case and requirements, considering factors such as audio quality, compatibility, file size, and efficiency, rather than solely focusing on minimizing latency.
+  Choose the audio format that best suits your specific use case and requirements, considering factors such as audio quality, compatibility, file size, and efficiency, rather than solely focusing on minimizing latency.
 </Info>
 
 ## More Tips to Minimize Latency
@@ -256,7 +256,3 @@ While this guide focuses on TTS latency, in the full context of a voice bot appl
 1. If self-hosted, can a smaller model be used, or can more powerful hardware be used to serve requests?
 2. If using an external API, does the provider offer their own set of latency recommendations? Do they offer certain parameters or product tiers that enable lower latency?
 3. Can you reduce the number of input or output tokens to produce a shorter reply? For instance, add a system prompt to reply in fewer than a certain number of words or sentences (e.g. "Reply in three sentences or less").
-
-### Open-Source Resources and Demos
-
-Try out our browser-based [AI Agent Conversational Demo](https://deepgram-conversational-demo.vercel.app/), and then jump start your own voice bot with its open-source implementation on GitHub at [deepgram-conversational-demo](https://github.com/deepgram-devs/deepgram-conversational-demo).

--- a/fern/docs/text-to-speech-prompting.mdx
+++ b/fern/docs/text-to-speech-prompting.mdx
@@ -28,7 +28,7 @@ A comma (`,`) or a period (`.`) present in your text will be treated as a very *
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":"Hello, how can I help you today? ... Are you there ... Hello?"}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -63,7 +63,7 @@ Silent pauses are pauses that have a higher probability of staying silent in the
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":"To confirm, is your registration number BY. . 3984. . 0297?"}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -82,7 +82,7 @@ Filler words such as `um` and `uh` can also be used to offer a more natural soun
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":"Hello, how can I help you today? um Are you there uh Hello?"}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -103,7 +103,7 @@ While we do not offer pronunciation control as part of our API, you can create s
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":" To confirm, is your referral code Queue Why. Eigh Beee?"}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -128,7 +128,7 @@ You can add natural pauses between groups of 2 - 4 alphabets to include pauses.
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":" To confirm, is your referral code Queue Why. Eigh Beee?"}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -147,7 +147,7 @@ In most cases, acronyms can be handled by just providing the letters of the acro
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":"I love watching NBA Basketball."}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -168,7 +168,7 @@ Explicitly add the word `and` to tell the model to pronounce the entire phrase a
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":"The total is 1235, or twelve hundred and thirty-five."}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -191,7 +191,7 @@ If you are having trouble with words rooted in different languages in your text,
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":"I want to rahn-day-voo with you."}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 

--- a/fern/docs/text-to-speech.mdx
+++ b/fern/docs/text-to-speech.mdx
@@ -225,7 +225,7 @@ Open your terminal, navigate to the location on your drive where you want to cre
 
           # STEP 2 Call the save method on the speak property
           options = SpeakOptions(
-              model="aura-asteria-en",
+              model="aura-2-thalia-en",
           )
 
           response = deepgram.speak.rest.v("1").save(filename, SPEAK_TEXT, options)

--- a/fern/docs/text-to-speech.mdx
+++ b/fern/docs/text-to-speech.mdx
@@ -36,7 +36,7 @@ Next, try it with CURL. Add your own API key where it says `YOUR_DEEPGRAM_API_KE
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
        --data '{"text":"Hello, how can I help you today?"}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en"
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
 </CodeGroup>
 
@@ -62,7 +62,7 @@ To see the error message in your terminal, add this to your CURL request:
   ```
 </CodeGroup>
 
-This example will capture the error message using `jq` and remove the output file (tts.mp3) automatically.
+This example will capture the error message using the [JQ](https://jqlang.org/) JSON processor library and remove the output file `tts.mp3` automatically.
 
 <CodeGroup>
   ```bash cURL
@@ -154,7 +154,7 @@ Open your terminal, navigate to the location on your drive where you want to cre
     const response = await deepgram.speak.request(
       { text },
       {
-        model: "aura-asteria-en",
+        model: "aura-2-thalia-en",
         encoding: "linear16",
         container: "wav",
       }
@@ -268,7 +268,7 @@ Open your terminal, navigate to the location on your drive where you want to cre
 
   	// STEP 3: define options for the request
   	options := interfaces.SpeakOptions{
-  		Model:     "aura-asteria-en",
+  		Model:     "aura-2-thalia-en",
   		Encoding:  "linear16",
   		Container: "wav",
   	}
@@ -324,7 +324,7 @@ Open your terminal, navigate to the location on your drive where you want to cre
                   "test.mp3",
                   new SpeakSchema()
                   {
-                      Model = "aura-asteria-en",
+                      Model = "aura-2-thalia-en",
                   });
 
               //Console.WriteLine(response);
@@ -361,7 +361,7 @@ Upon successful processing of the request, you will receive an audio file contai
   ```text http
   HTTP/1.1 200 OK
   < content-type: audio/mpeg
-  < dg-model-name: aura-asteria-en
+  < dg-model-name: aura-2-thalia-en
   < dg-model-uuid: e4979ab0-8475-4901-9d66-0a562a4949bb
   < dg-char-count: 32
   < dg-request-id: bf6fc5c7-8f84-479f-b70a-602cf5bf18f3
@@ -395,18 +395,17 @@ Keep these limits in mind when making a Deepgram text-to-speech request.
 
 ### Rate Limits
 
-* **Pay As You Go Plan**: 480 requests per minute.
-* **Growth Plan**: 720 requests per minute.
-
 <Info>
-  The current rate limit per project is 480 requests per minute for Pay As You Go and 720 requests per minute for Growth plans. Learn more at Deepgram's [pricing page](https://deepgram.com/pricing) or [share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit).
+  For information on Deepgram's Concurrency Rate Limits, refer to our [API Rate Limits Documentation](/reference/api-rate-limits).
 </Info>
 
 #### Handling Rate Limits
 
-* If the number of in-progress requests for a project meets or exceeds the rate limit, new requests will receive a **429: Too Many Requests** error.
-* With a typical response time of 250ms, users of our Pay As You Go or Growth plans can achieve a request rate of roughly:\
-  `2 (concurrent requests) / 0.250 (250 ms response time) * 60 (seconds/minute) = 480 requests per minute.`
+If the number of in-progress requests for a project meets or exceeds the rate limit, new requests will receive a **429: Too Many Requests** error.
+
+<Info>
+  For suggestions on handling Concurrency Rate Limits, refer to our [Working with Concurrency Rate Limits Documentation](/docs/working-with-concurrency-rate-limits) guide.
+</Info>
 
 ## What's Next?
 
@@ -414,7 +413,7 @@ Now that you've transformed text into speech with Deepgram's API, enhance your k
 
 ### Starter Apps
 
-* Clone and run one of our [Starter App](/docs/stt-pre-recorded-starter-apps) repositories to see a full application with a frontend UI and a backend server sending text to Deepgram to be converted into audio.
+* Clone and run one of our [Starter App](/docs/tts-starter-apps#text-to-speech-rest) repositories to see a full application with a frontend UI and a backend server sending text to Deepgram to be converted into audio.
 
 ### Read the Feature Guides
 
@@ -424,20 +423,12 @@ Deepgram's features help you to customize your request to produce the output tha
 * [Callback](/docs/tts-callback): Discover how to provide a callback url, so that your audio can be processed asynchronously.
 * [Feature Overview](/docs/tts-feature-overview): Review the list of features available for pre-recorded speech-to-text. Then, dive into individual guides for more details.
 
-### Transcribe Speech-to-Text
-
-* Check out how you can use Deepgram to turn audio into text. Read the [Pre-Recorded Speech-To-Text](/docs/getting-started-with-pre-recorded-audio) guide or the [Streaming Speech-To-Text Guide](/docs/getting-started-with-live-streaming-audio).
-
 ### Try the Conversational AI Demo
 
 * The purpose of[ this demo](https://aura-tts-demo.deepgram.com/) is to showcase how you can build a Conversational AI application that engages users in natural language interactions, mimicking human conversation through natural language processing using Deepgram and [OpenAI ChatGPT.](https://openai.com/chatgpt)
 
 ### Watch This Video
 
-* See how you can use Deepgram Aura with [Groq](https://groq.com/) to build a blazing fast Conversational AI application.
-
-<Info>
-  We'd love to get your feedback on Deepgram's Aura text-to-speech. You will receive $50 in additional console credits within two weeks after filling out the form, and you may be invited to join a group of users with access to the latest private releases. To fill out the form, [Click Here](https://deepgram.typeform.com/to/mcRYgKbd).
-</Info>
+* Watch this [video](https://www.youtube.com/watch?v=J2sbC8X5Pp8) to learn how you can use Deepgram Aura with [Groq](https://groq.com/) to build a blazing fast Conversational AI application.
 
 ***

--- a/fern/docs/tts-bit-rate.mdx
+++ b/fern/docs/tts-bit-rate.mdx
@@ -36,20 +36,22 @@ To enable the Bit Rate feature, include the `bit_rate` parameter in the query st
 You can use the following cURL command in a terminal or your favorite API client to synthesize text into speech with a specific bitrate.
 
 **MP3 encoding with bitrate of 32 kbits/second:**:
-
 <CodeGroup>
   ```bash cURL
   curl --request POST \
-       --header "Content-Type: application/json" \
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=mp3&bit_rate=32000" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
-       --output your_output_file.mp3 \
-       --data '{"text":"Hello, how can I help you today?"}' \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=mp3&bit_rate=32000" \
+       --header 'Content-Type: application/json' \
+       --data '{"text": "Hello, how can I help you today?"}' \
+       --output outputfile_mp3_32000.mp3 \
        --fail-with-body \
-       --silent \
-       || (jq . your_output_file.mp3 && rm your_output_file.mp3)
+       --silent || echo "Request failed"
   ```
 </CodeGroup>
+
+<Warning>
+  Replace `YOUR_DEEPGRAM_API_KEY` with your [Deepgram API Key](/docs/create-additional-api-keys).
+</Warning>
 
 ### Query Parameters
 
@@ -71,7 +73,7 @@ Upon successful processing of the request, you will receive an audio file contai
   ```text http
   HTTP/1.1 200 OK
   < content-type: audio/mpeg
-  < dg-model-name: aura-asteria-en
+  < dg-model-name: aura-2-thalia-en
   < dg-model-uuid: e4979ab0-8475-4901-9d66-0a562a4949bb
   < dg-char-count: 32
   < dg-request-id: bf6fc5c7-8f84-479f-b70a-602cf5bf18f3
@@ -93,9 +95,3 @@ This includes:
 * `dg-model-name`: The name of the model used to process the request.
 * `transfer-encoding`: Specifies the form of encoding used to safely transfer the payload to the recipient.
 * `date`: The date and time the response was sent.
-
-## API Error Responses
-
-<Info>
-  For information on Deepgram's error messages and error codes, read the API Reference [Errors](/reference/errors) page.
-</Info>

--- a/fern/docs/tts-callback.mdx
+++ b/fern/docs/tts-callback.mdx
@@ -30,7 +30,7 @@ To synthesize text-to-speech and generate an audio file, run the following cURL 
     --header 'Authorization: Token YOUR_DEEPGRAM_API_KEY' \
     --header 'Content-Type: application/json' \
     --data '{"text": "Hello, how can I help you today?"}'
-    --url 'https://api.deepgram.com/v1/speak?callback=URL'
+    --url 'https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&callback=URL'
   ```
 </CodeGroup>
 

--- a/fern/docs/tts-container.mdx
+++ b/fern/docs/tts-container.mdx
@@ -24,7 +24,7 @@ Choosing the appropriate container format for the audio output is essential for 
 To enable the Container feature, include the `container` parameter in the query string with the desired container format value.
 
 <CodeGroup>
-  ```shell Shell
+  ```text Text
   https://api.deepgram.com/v1/speak?encoding=linear16&container=wav
   ```
 </CodeGroup>
@@ -42,16 +42,19 @@ You can use the following cURL command in a terminal or your favorite API client
 <CodeGroup>
   ```bash cURL
   curl --request POST \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=linear16&container=wav" \
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&container=wav" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --header 'Content-Type: application/json' \
+       --data '{"text": "Hello, how can I help you today?"}' \
        --output container_wav_output.wav \
-       --data '{"text": "Hello, how can I help you today?"}'
        --fail-with-body \
-       --silent \
-       || (jq . container_wav_output.wav && rm container_wav_output.wav)
+       --silent || echo "Request failed"
   ```
 </CodeGroup>
+
+<Warning>
+  Replace `YOUR_DEEPGRAM_API_KEY` with your [Deepgram API Key](/docs/create-additional-api-keys).
+</Warning>
 
 ### Query Parameters
 
@@ -59,9 +62,9 @@ You can use the following cURL command in a terminal or your favorite API client
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------- |
 | `container` | See list of supported audio format combinations in the [Audio Format Combinations table](/docs/tts-media-output-settings#audio-format-combinations). | `string` | The desired file format wrapper for the output audio. |
 
-<Warning>
+<Info>
   When using VoIP (Voice over Internet Protocol), we recommend adding `container=none` to your request to prevent request header information being misinterpreted as audio, which can result in static or click sounds.
-</Warning>
+</Info>
 
 ## Analyze Response
 
@@ -99,9 +102,3 @@ This includes:
 * `dg-model-name`: The name of the model used to process the request.
 * `transfer-encoding`: Specifies the form of encoding used to safely transfer the payload to the recipient.
 * `date`: The date and time the response was sent.
-
-## API Error Responses
-
-<Info>
-  For information on Deepgram's error messages and error codes, read the API Reference [Errors](/reference/errors) page.
-</Info>

--- a/fern/docs/tts-container.mdx
+++ b/fern/docs/tts-container.mdx
@@ -80,7 +80,7 @@ Upon successful processing of the request, you will receive an audio file contai
   ```text http
   HTTP/1.1 200 OK
   < content-type: audio/mpeg
-  < dg-model-name: aura-asteria-en
+  < dg-model-name: aura-2-thalia-en
   < dg-model-uuid: e4979ab0-8475-4901-9d66-0a562a4949bb
   < dg-char-count: 32
   < dg-request-id: bf6fc5c7-8f84-479f-b70a-602cf5bf18f3

--- a/fern/docs/tts-encoding.mdx
+++ b/fern/docs/tts-encoding.mdx
@@ -13,10 +13,6 @@ slug: docs/tts-encoding
 
 The Encoding feature gives users the ability to specify the desired format of the resulting text-to-speech audio output.
 
-<Info>
-  The following encoding options are supported for Rest or Streaming.
-</Info>
-
 | Encoding     | Description                                 | Availability        |
 | ------------ | ------------------------------------------- | ------------------- |
 | **linear16** | 16-bit, little-endian, signed PCM WAV data. | `REST` ,`Streaming` |
@@ -48,14 +44,13 @@ You can use the following cURL command in a terminal or your favorite API client
 <CodeGroup>
   ```bash cURL
   curl --request POST \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=linear16&container=wav" \
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&container=wav" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --header 'Content-Type: application/json' \
-       --output outputfile_Linear16.wav \
        --data '{"text": "Hello, how can I help you today?"}' \
+       --output outputfile_Linear16.wav \
        --fail-with-body \
-       --silent \
-       || (jq . outputfile_Linear16.wav && rm outputfile_Linear16.wav)
+       --silent || echo "Request failed"
   ```
 </CodeGroup>
 
@@ -63,17 +58,20 @@ You can use the following cURL command in a terminal or your favorite API client
 
 <CodeGroup>
   ```bash cURL
-  `curl --request POST \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=mp3&bit_rate=32000" \
+  curl --request POST \
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=mp3&bit_rate=32000" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --header 'Content-Type: application/json' \
-       --output outputfile_mp3_32000.mp3 \
        --data '{"text": "Hello, how can I help you today?"}' \
+       --output outputfile_mp3_32000.mp3 \
        --fail-with-body \
-       --silent \
-       || (jq . outputfile_mp3_32000.mp3 && rm outputfile_mp3_32000.mp3)`
+       --silent || echo "Request failed"
   ```
 </CodeGroup>
+
+<Warning>
+  Replace `YOUR_DEEPGRAM_API_KEY` with your [Deepgram API Key](/docs/create-additional-api-keys).
+</Warning>
 
 ### Query Parameters
 
@@ -95,7 +93,7 @@ Upon successful processing of the request, you will receive an audio file contai
   ```text http
   HTTP/1.1 200 OK
   < content-type: audio/mpeg
-  < dg-model-name: aura-asteria-en
+  < dg-model-name: aura-2-thalia-en
   < dg-model-uuid: e4979ab0-8475-4901-9d66-0a562a4949bb
   < dg-char-count: 32
   < dg-request-id: bf6fc5c7-8f84-479f-b70a-602cf5bf18f3
@@ -117,9 +115,3 @@ This includes:
 * `dg-model-name`: The name of the model used to process the request.
 * `transfer-encoding`: Specifies the form of encoding used to safely transfer the payload to the recipient.
 * `date`: The date and time the response was sent.
-
-## API Error Responses
-
-<Info>
-  For information on Deepgram's error messages and error codes, read the API Reference [Errors](/reference/errors) page.
-</Info>

--- a/fern/docs/tts-feature-overview.mdx
+++ b/fern/docs/tts-feature-overview.mdx
@@ -29,11 +29,6 @@ slug: docs/tts-feature-overview
 | [Callback](/docs/tts-callback)                             |
 | [Audio Output Streaming](/docs/streaming-the-audio-output) |
 
-## Pause and Pronunciation Control
-
-<Info>
-  While we do not offer pause and pronunciation control as part of our API, check out our [Tips and Tricks Guide](/docs/text-to-speech-prompting) to learn how to prompt our model to include pauses and gain more control over pronunciation.
-</Info>
 
 ## Rate Limits
 

--- a/fern/docs/tts-models.mdx
+++ b/fern/docs/tts-models.mdx
@@ -13,22 +13,100 @@ slug: docs/tts-models
 
 Deepgram offers a range of voices for its Aura text-to-speech API, each identified by a unique model name following the format `[modelname]-[voicename]-[language]`.
 
-To select a model, use the syntax `model=aura-asteria-en`
+To select a model, use the syntax `model=aura-2-thalia-en`
 
-| Voice Name | Accent | Gender | Values | Listen |
-| --- | --- | --- | --- | --- |
-| Asteria | English (US) | Female | `aura-asteria-en` | <audio id="asteria" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565353/aura/asteria_docs_venw0r.wav"></audio> |
-| Luna | English (US) | Female | `aura-luna-en` | <audio id="luna" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565351/aura/luna_docs_clom0e.wav"></audio> |
-| Stella | English (US) | Female | `aura-stella-en` | <audio id="stella" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565349/aura/stella_docs_xh5jbv.wav"></audio> |
-| Athena | English (UK) | Female | `aura-athena-en` | <audio id="athena" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565613/aura/athena_docs_wyznud.wav"></audio> |
-| Hera | English (US) | Female | `aura-hera-en` | <audio id="hera" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565347/aura/hera_docs_xjkt4x.wav"></audio> |
-| Orion | English (US) | Male | `aura-orion-en` | <audio id="orion" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565346/aura/orion_docs_aljv1q.mp3"></audio> |
-| Arcas | English (US) | Male | `aura-arcas-en` | <audio id="arcas" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565348/aura/arcas_docs_pc9hxp.mp3"></audio> |
-| Perseus | English (US) | Male | `aura-perseus-en` | <audio id="perseus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565350/aura/perseus_docs_ap7fc0.wav"></audio> |
-| Angus | English (Ireland) | Male | `aura-angus-en` | <audio id="angus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565352/aura/angus_docs_lgse2b.wav"></audio> |
-| Orpheus | English (US) | Male | `aura-orpheus-en` | <audio id="orpheus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565350/aura/orpheus_docs_zdlpcf.wav"></audio> |
-| Helios | English (UK) | Male | `aura-helios-en` | <audio id="helios" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565346/aura/helios_docs_ycjwoo.wav"></audio> |
-| Zeus | English (US) | Male | `aura-zeus-en` | <audio id="zeus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565347/aura/zeus_docs_fupdiv.wav"></audio> |
+## Example
+<CodeGroup >
+```curl CURL
+curl "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en" \
+> -H "Content-Type: application/json" \
+> -H "Authorization: Token YOUR_DEEPGRAM_API_KEY" \
+> -d "{\"text\":\"Hello how are you?\"}" \
+> --output outputfile_voice_model.wav \
+> --fail-with-body \
+> --silent || echo "Request failed"
+```
+</CodeGroup>
+
+<Warning>
+  Replace `YOUR_DEEPGRAM_API_KEY` with your [Deepgram API Key](/docs/create-additional-api-keys).
+</Warning>
+
+## Featured Voices
+
+These are our featured voices, selected for their versatility and quality:
+
+| model | name | expressed gender | age | accent | language | characteristics | use cases | audio sample |
+| :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
+| `aura-2-thalia-en` | thalia | feminine | Adult | en-us | American | Clear, Confident, Energetic, Enthusiastic | Casual chat, customer service, IVR | <audio id="thalia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
+| `aura-2-andromeda-en` | andromeda | feminine | Adult | en-us | American | Casual, Expressive, Comfortable | Customer service, IVR | <audio id="andromeda" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-andromeda.wav"></audio> |
+| `aura-2-helena-en` | helena | feminine | Adult | en-us | American | Caring, Natural, Positive, Friendly, Raspy | IVR, casual chat | <audio id="helena" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-helena.wav"></audio> |
+| `aura-2-apollo-en` | apollo | masculine | Adult | en-us | American | Confident, Comfortable, Casual | Casual chat | <audio id="apollo" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-apollo.wav"></audio> |
+| `aura-2-arcas-en` | arcas | masculine | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-arcas.wav"></audio> |
+| `aura-2-aries-en` | aries | masculine | Adult | en-us | American | Warm, Energetic, Caring | Casual chat | <audio id="aries" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-aries.wav"></audio> |
+
+## Aura-2 All Available Voices
+
+| model | name | expressed gender | age | accent | language | characteristics | use cases | audio sample |
+| :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
+| `aura-2-amalthea-en` | amalthea | female | Young Adult | en-ph | Filipino | Engaging, Natural, Cheerful | Casual chat | <audio id="amalthea" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-amalthea.wav"></audio> |
+| `aura-2-andromeda-en` | andromeda | female | Adult | en-us | American | Casual, Expressive, Comfortable | Customer service, IVR | <audio id="andromeda" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-andromeda.wav"></audio> |
+| `aura-2-apollo-en` | apollo | male | Adult | en-us | American | Confident, Comfortable, Casual | Casual chat | <audio id="apollo" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-apollo.wav"></audio> |
+| `aura-2-arcas-en` | arcas | male | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-arcas.wav"></audio> |
+| `aura-2-aries-en` | aries | male | Adult | en-us | American | Warm, Energetic, Caring | Casual chat | <audio id="aries" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-aries.wav"></audio> |
+| `aura-2-asteria-en` | asteria | female | Adult | en-us | American | Clear, Confident, Knowledgeable, Energetic | Advertising | <audio id="asteria" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-asteria.wav"></audio> |
+| `aura-2-athena-en` | athena | female | Mature | en-us | American | Calm, Smooth, Professional | Storytelling | <audio id="athena" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-athena.wav"></audio> |
+| `aura-2-atlas-en` | atlas | male | Mature | en-us | American | Enthusiastic, Confident, Approachable, Friendly | Advertising | <audio id="atlas" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-atlas.wav"></audio> |
+| `aura-2-aurora-en` | aurora | female | Adult | en-us | American | Cheerful, Expressive, Energetic | Interview | <audio id="aurora" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-aurora.wav"></audio> |
+| `aura-2-callista-en` | callista | female | Adult | en-us | American | Clear, Energetic, Professional, Smooth | IVR | <audio id="callista" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-callista.wav"></audio> |
+| `aura-2-cora-en` | cora | female | Adult | en-us | American | Smooth, Melodic, Caring | Storytelling | <audio id="cora" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-cora.wav"></audio> |
+| `aura-2-cordelia-en` | cordelia | female | Young Adult | en-us | American | Approachable, Warm, Polite | Storytelling | <audio id="cordelia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-cordelia.wav"></audio> |
+| `aura-2-delia-en` | delia | female | Young Adult | en-us | American | Casual, Friendly, Cheerful, Breathy | Interview | <audio id="delia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-delia.wav"></audio> |
+| `aura-2-draco-en` | draco | male | Adult | en-gb | British | Warm, Approachable, Trustworthy, Baritone | Storytelling | <audio id="draco" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-draco.wav"></audio> |
+| `aura-2-electra-en` | electra | female | Adult | en-us | American | Professional, Engaging, Knowledgeable | IVR, advertising, customer service | <audio id="electra" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-electra.wav"></audio> |
+| `aura-2-harmonia-en` | harmonia | female | Adult | en-us | American | Empathetic, Clear, Calm, Confident | Customer service | <audio id="harmonia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-harmonia.wav"></audio> |
+| `aura-2-helena-en` | helena | female | Adult | en-us | American | Caring, Natural, Positive, Friendly, Raspy | IVR, casual chat | <audio id="helena" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-helena.wav"></audio> |
+| `aura-2-hera-en` | hera | female | Adult | en-us | American | Smooth, Warm, Professional | Informative | <audio id="hera" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-hera.wav"></audio> |
+| `aura-2-hermes-en` | hermes | male | Adult | en-us | American | Expressive, Engaging, Professional | Informative | <audio id="hermes" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
+| `aura-2-hyperion-en` | hyperion | male | Adult | en-au | Australian | Caring, Warm, Empathetic | Interview | <audio id="hyperion" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-hyperion.wav"></audio> |
+| `aura-2-iris-en` | iris | female | Young Adult | en-us | American | Cheerful, Positive, Approachable | IVR, advertising, customer service | <audio id="iris" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-iris.wav"></audio> |
+| `aura-2-janus-en` | janus | female | Adult | en-us | American | Southern, Smooth, Trustworthy | Storytelling | <audio id="janus" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-janus.wav"></audio> |
+| `aura-2-juno-en` | juno | female | Adult | en-us | American | Natural, Engaging, Melodic, Breathy | Interview | <audio id="juno" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-juno.wav"></audio> |
+| `aura-2-jupiter-en` | jupiter | male | Adult | en-us | American | Expressive, Knowledgeable, Baritone | Informative | <audio id="jupiter" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-jupiter.wav"></audio> |
+| `aura-2-luna-en` | luna | female | Young Adult | en-us | American | Friendly, Natural, Engaging | IVR | <audio id="luna" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-luna.wav"></audio> |
+| `aura-2-mars-en` | mars | male | Adult | en-us | American | Smooth, Patient, Trustworthy, Baritone | Customer service | <audio id="mars" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-mars.wav"></audio> |
+| `aura-2-minerva-en` | minerva | female | Adult | en-us | American | Positive, Friendly, Natural | Storytelling | <audio id="minerva" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-minerva.wav"></audio> |
+| `aura-2-neptune-en` | neptune | male | Adult | en-us | American | Professional, Patient, Polite | Customer service | <audio id="neptune" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-neptune.wav"></audio> |
+| `aura-2-odysseus-en` | odysseus | male | Adult | en-us | American | Calm, Smooth, Comfortable, Professional | Advertising | <audio id="odysseus" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-odysseus.wav"></audio> |
+| `aura-2-ophelia-en` | ophelia | female | Adult | en-us | American | Expressive, Enthusiastic, Cheerful | Interview | <audio id="ophelia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-ophelia.wav"></audio> |
+| `aura-2-orion-en` | orion | male | Adult | en-us | American | Approachable, Comfortable, Calm, Polite | Informative | <audio id="orion" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-orion.wav"></audio> |
+| `aura-2-orpheus-en` | orpheus | male | Adult | en-us | American | Professional, Clear, Confident, Trustworthy | Customer service, storytelling | <audio id="orpheus" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-orpheus.wav"></audio> |
+| `aura-2-pandora-en` | pandora | female | Adult | en-gb | British | Smooth, Calm, Melodic, Breathy | IVR, informative | <audio id="pandora" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-pandora.wav"></audio> |
+| `aura-2-phoebe-en` | phoebe | female | Adult | en-us | American | Energetic, Warm, Casual | Customer service | <audio id="phoebe" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-phoebe.wav"></audio> |
+| `aura-2-pluto-en` | pluto | male | Adult | en-us | American | Smooth, Calm, Empathetic, Baritone | Interview, storytelling | <audio id="pluto" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-pluto.wav"></audio> |
+| `aura-2-saturn-en` | saturn | male | Adult | en-us | American | Knowledgeable, Confident, Baritone | Customer service | <audio id="saturn" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-saturn.wav"></audio> |
+| `aura-2-selene-en` | selene | female | Adult | en-us | American | Expressive, Engaging, Energetic | Informative | <audio id="selene" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-selene.wav"></audio> |
+| `aura-2-thalia-en` | thalia | female | Adult | en-us | American | Clear, Confident, Energetic, Enthusiastic | Casual chat, customer service, IVR | <audio id="thalia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
+| `aura-2-theia-en` | theia | female | Adult | en-au | American | Expressive, Polite, Sincere | Informative | <audio id="theia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-theia.wav"></audio> |
+| `aura-2-vesta-en` | vesta | female | Adult | en-us | American | Natural, Expressive, Patient, Empathetic | Customer service, interview, storytelling | <audio id="vesta" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-vesta.wav"></audio> |
+| `aura-2-zeus-en` | zeus | male | Adult | en-us | American | Deep, Trustworthy, Smooth | IVR | <audio id="zeus" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-zeus.wav"></audio> |
+
+## Aura 1: All Available Voices
+
+| model | name | expressed gender | age | accent | language | characteristics | use cases | audio sample |
+| :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
+| `aura-asteria-en` | asteria | female | Adult | en-us | American | Clear, Confident, Knowledgeable, Energetic | Advertising | <audio id="asteria" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565353/aura/asteria_docs_venw0r.wav"></audio> |
+| `aura-luna-en` | luna | female | Young Adult | en-us | American | Friendly, Natural, Engaging | IVR | <audio id="luna" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565351/aura/luna_docs_clom0e.wav"></audio> |
+| `aura-stella-en` | stella | female | Adult | en-us | American | Clear, Professional, Engaging | Customer service | <audio id="stella" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565349/aura/stella_docs_xh5jbv.wav"></audio> |
+| `aura-athena-en` | athena | female | Mature | en-gb | British | Calm, Smooth, Professional | Storytelling | <audio id="athena" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565613/aura/athena_docs_wyznud.wav"></audio> |
+| `aura-hera-en` | hera | female | Adult | en-us | American | Smooth, Warm, Professional | Informative | <audio id="hera" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565347/aura/hera_docs_xjkt4x.wav"></audio> |
+| `aura-orion-en` | orion | male | Adult | en-us | American | Approachable, Comfortable, Calm, Polite | Informative | <audio id="orion" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565346/aura/orion_docs_aljv1q.mp3"></audio> |
+| `aura-arcas-en` | arcas | male | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565348/aura/arcas_docs_pc9hxp.mp3"></audio> |
+| `aura-perseus-en` | perseus | male | Adult | en-us | American | Confident, Professional, Clear | Customer service | <audio id="perseus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565350/aura/perseus_docs_ap7fc0.wav"></audio> |
+| `aura-angus-en` | angus | male | Adult | en-ie | Irish | Warm, Friendly, Natural | Storytelling | <audio id="angus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565352/aura/angus_docs_lgse2b.wav"></audio> |
+| `aura-orpheus-en` | orpheus | male | Adult | en-us | American | Professional, Clear, Confident, Trustworthy | Customer service, storytelling | <audio id="orpheus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565350/aura/orpheus_docs_zdlpcf.wav"></audio> |
+| `aura-helios-en` | helios | male | Adult | en-gb | British | Professional, Clear, Confident | Customer service | <audio id="helios" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565346/aura/helios_docs_ycjwoo.wav"></audio> |
+| `aura-zeus-en` | zeus | male | Adult | en-us | American | Deep, Trustworthy, Smooth | IVR | <audio id="zeus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565347/aura/zeus_docs_fupdiv.wav"></audio> |
 
 <Info>
   We'd love to get your feedback on Deepgram's Aura Text-to-Speech voice models. Let us know which languages you need by [completing this survey.](https://deepgram.typeform.com/aura-languages)

--- a/fern/docs/tts-models.mdx
+++ b/fern/docs/tts-models.mdx
@@ -36,80 +36,88 @@ curl "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en" \
 
 These are our featured voices, selected for their versatility and quality:
 
-| model | name | expressed gender | age | accent | language | characteristics | use cases | audio sample |
+<div className="voice-model-table">
+
+| Model | Name | Expressed Gender | Age | Accent | Language | Characteristics | Use Cases | Sample|
 | :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
-| `aura-2-thalia-en` | thalia | feminine | Adult | en-us | American | Clear, Confident, Energetic, Enthusiastic | Casual chat, customer service, IVR | <audio id="thalia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
-| `aura-2-andromeda-en` | andromeda | feminine | Adult | en-us | American | Casual, Expressive, Comfortable | Customer service, IVR | <audio id="andromeda" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-andromeda.wav"></audio> |
-| `aura-2-helena-en` | helena | feminine | Adult | en-us | American | Caring, Natural, Positive, Friendly, Raspy | IVR, casual chat | <audio id="helena" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-helena.wav"></audio> |
-| `aura-2-apollo-en` | apollo | masculine | Adult | en-us | American | Confident, Comfortable, Casual | Casual chat | <audio id="apollo" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-apollo.wav"></audio> |
-| `aura-2-arcas-en` | arcas | masculine | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-arcas.wav"></audio> |
-| `aura-2-aries-en` | aries | masculine | Adult | en-us | American | Warm, Energetic, Caring | Casual chat | <audio id="aries" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-aries.wav"></audio> |
+| `aura-2-thalia-en` | thalia | feminine | Adult | en-us | American | Clear, Confident, Energetic, Enthusiastic | Casual chat, customer service, IVR | <audio id="thalia"  controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
+| `aura-2-andromeda-en` | andromeda | feminine | Adult | en-us | American | Casual, Expressive, Comfortable | Customer service, IVR | <audio id="andromeda"  controls src="https://static.deepgram.com/examples/Aura-2-andromeda.wav"></audio> |
+| `aura-2-helena-en` | helena | feminine | Adult | en-us | American | Caring, Natural, Positive, Friendly, Raspy | IVR, casual chat | <audio id="helena"  controls src="https://static.deepgram.com/examples/Aura-2-helena.wav"></audio> |
+| `aura-2-apollo-en` | apollo | masculine | Adult | en-us | American | Confident, Comfortable, Casual | Casual chat | <audio id="apollo"  controls src="https://static.deepgram.com/examples/Aura-2-apollo.wav"></audio> |
+| `aura-2-arcas-en` | arcas | masculine | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas"  controls src="https://static.deepgram.com/examples/Aura-2-arcas.wav"></audio> |
+| `aura-2-aries-en` | aries | masculine | Adult | en-us | American | Warm, Energetic, Caring | Casual chat | <audio id="aries"  controls src="https://static.deepgram.com/examples/Aura-2-aries.wav"></audio> |
+
+</div>
 
 ## Aura-2 All Available Voices
 
-| model | name | expressed gender | age | accent | language | characteristics | use cases | audio sample |
+<div className="voice-model-table">
+
+| Model | Name | Expressed Gender | Age | Accent | Language | Characteristics | Use Cases | Sample |
 | :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
-| `aura-2-amalthea-en` | amalthea | female | Young Adult | en-ph | Filipino | Engaging, Natural, Cheerful | Casual chat | <audio id="amalthea" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-amalthea.wav"></audio> |
-| `aura-2-andromeda-en` | andromeda | female | Adult | en-us | American | Casual, Expressive, Comfortable | Customer service, IVR | <audio id="andromeda" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-andromeda.wav"></audio> |
-| `aura-2-apollo-en` | apollo | male | Adult | en-us | American | Confident, Comfortable, Casual | Casual chat | <audio id="apollo" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-apollo.wav"></audio> |
-| `aura-2-arcas-en` | arcas | male | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-arcas.wav"></audio> |
-| `aura-2-aries-en` | aries | male | Adult | en-us | American | Warm, Energetic, Caring | Casual chat | <audio id="aries" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-aries.wav"></audio> |
-| `aura-2-asteria-en` | asteria | female | Adult | en-us | American | Clear, Confident, Knowledgeable, Energetic | Advertising | <audio id="asteria" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-asteria.wav"></audio> |
-| `aura-2-athena-en` | athena | female | Mature | en-us | American | Calm, Smooth, Professional | Storytelling | <audio id="athena" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-athena.wav"></audio> |
-| `aura-2-atlas-en` | atlas | male | Mature | en-us | American | Enthusiastic, Confident, Approachable, Friendly | Advertising | <audio id="atlas" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-atlas.wav"></audio> |
-| `aura-2-aurora-en` | aurora | female | Adult | en-us | American | Cheerful, Expressive, Energetic | Interview | <audio id="aurora" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-aurora.wav"></audio> |
-| `aura-2-callista-en` | callista | female | Adult | en-us | American | Clear, Energetic, Professional, Smooth | IVR | <audio id="callista" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-callista.wav"></audio> |
-| `aura-2-cora-en` | cora | female | Adult | en-us | American | Smooth, Melodic, Caring | Storytelling | <audio id="cora" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-cora.wav"></audio> |
-| `aura-2-cordelia-en` | cordelia | female | Young Adult | en-us | American | Approachable, Warm, Polite | Storytelling | <audio id="cordelia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-cordelia.wav"></audio> |
-| `aura-2-delia-en` | delia | female | Young Adult | en-us | American | Casual, Friendly, Cheerful, Breathy | Interview | <audio id="delia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-delia.wav"></audio> |
-| `aura-2-draco-en` | draco | male | Adult | en-gb | British | Warm, Approachable, Trustworthy, Baritone | Storytelling | <audio id="draco" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-draco.wav"></audio> |
-| `aura-2-electra-en` | electra | female | Adult | en-us | American | Professional, Engaging, Knowledgeable | IVR, advertising, customer service | <audio id="electra" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-electra.wav"></audio> |
-| `aura-2-harmonia-en` | harmonia | female | Adult | en-us | American | Empathetic, Clear, Calm, Confident | Customer service | <audio id="harmonia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-harmonia.wav"></audio> |
-| `aura-2-helena-en` | helena | female | Adult | en-us | American | Caring, Natural, Positive, Friendly, Raspy | IVR, casual chat | <audio id="helena" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-helena.wav"></audio> |
-| `aura-2-hera-en` | hera | female | Adult | en-us | American | Smooth, Warm, Professional | Informative | <audio id="hera" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-hera.wav"></audio> |
-| `aura-2-hermes-en` | hermes | male | Adult | en-us | American | Expressive, Engaging, Professional | Informative | <audio id="hermes" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
-| `aura-2-hyperion-en` | hyperion | male | Adult | en-au | Australian | Caring, Warm, Empathetic | Interview | <audio id="hyperion" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-hyperion.wav"></audio> |
-| `aura-2-iris-en` | iris | female | Young Adult | en-us | American | Cheerful, Positive, Approachable | IVR, advertising, customer service | <audio id="iris" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-iris.wav"></audio> |
-| `aura-2-janus-en` | janus | female | Adult | en-us | American | Southern, Smooth, Trustworthy | Storytelling | <audio id="janus" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-janus.wav"></audio> |
-| `aura-2-juno-en` | juno | female | Adult | en-us | American | Natural, Engaging, Melodic, Breathy | Interview | <audio id="juno" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-juno.wav"></audio> |
-| `aura-2-jupiter-en` | jupiter | male | Adult | en-us | American | Expressive, Knowledgeable, Baritone | Informative | <audio id="jupiter" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-jupiter.wav"></audio> |
-| `aura-2-luna-en` | luna | female | Young Adult | en-us | American | Friendly, Natural, Engaging | IVR | <audio id="luna" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-luna.wav"></audio> |
-| `aura-2-mars-en` | mars | male | Adult | en-us | American | Smooth, Patient, Trustworthy, Baritone | Customer service | <audio id="mars" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-mars.wav"></audio> |
-| `aura-2-minerva-en` | minerva | female | Adult | en-us | American | Positive, Friendly, Natural | Storytelling | <audio id="minerva" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-minerva.wav"></audio> |
-| `aura-2-neptune-en` | neptune | male | Adult | en-us | American | Professional, Patient, Polite | Customer service | <audio id="neptune" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-neptune.wav"></audio> |
-| `aura-2-odysseus-en` | odysseus | male | Adult | en-us | American | Calm, Smooth, Comfortable, Professional | Advertising | <audio id="odysseus" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-odysseus.wav"></audio> |
-| `aura-2-ophelia-en` | ophelia | female | Adult | en-us | American | Expressive, Enthusiastic, Cheerful | Interview | <audio id="ophelia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-ophelia.wav"></audio> |
-| `aura-2-orion-en` | orion | male | Adult | en-us | American | Approachable, Comfortable, Calm, Polite | Informative | <audio id="orion" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-orion.wav"></audio> |
-| `aura-2-orpheus-en` | orpheus | male | Adult | en-us | American | Professional, Clear, Confident, Trustworthy | Customer service, storytelling | <audio id="orpheus" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-orpheus.wav"></audio> |
-| `aura-2-pandora-en` | pandora | female | Adult | en-gb | British | Smooth, Calm, Melodic, Breathy | IVR, informative | <audio id="pandora" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-pandora.wav"></audio> |
-| `aura-2-phoebe-en` | phoebe | female | Adult | en-us | American | Energetic, Warm, Casual | Customer service | <audio id="phoebe" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-phoebe.wav"></audio> |
-| `aura-2-pluto-en` | pluto | male | Adult | en-us | American | Smooth, Calm, Empathetic, Baritone | Interview, storytelling | <audio id="pluto" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-pluto.wav"></audio> |
-| `aura-2-saturn-en` | saturn | male | Adult | en-us | American | Knowledgeable, Confident, Baritone | Customer service | <audio id="saturn" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-saturn.wav"></audio> |
-| `aura-2-selene-en` | selene | female | Adult | en-us | American | Expressive, Engaging, Energetic | Informative | <audio id="selene" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-selene.wav"></audio> |
-| `aura-2-thalia-en` | thalia | female | Adult | en-us | American | Clear, Confident, Energetic, Enthusiastic | Casual chat, customer service, IVR | <audio id="thalia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
-| `aura-2-theia-en` | theia | female | Adult | en-au | American | Expressive, Polite, Sincere | Informative | <audio id="theia" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-theia.wav"></audio> |
-| `aura-2-vesta-en` | vesta | female | Adult | en-us | American | Natural, Expressive, Patient, Empathetic | Customer service, interview, storytelling | <audio id="vesta" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-vesta.wav"></audio> |
-| `aura-2-zeus-en` | zeus | male | Adult | en-us | American | Deep, Trustworthy, Smooth | IVR | <audio id="zeus" style="width:188px;" controls src="https://static.deepgram.com/examples/Aura-2-zeus.wav"></audio> |
+| `aura-2-amalthea-en` | amalthea | feminine | Young Adult | en-ph | Filipino | Engaging, Natural, Cheerful | Casual chat | <audio id="amalthea" controls src="https://static.deepgram.com/examples/Aura-2-amalthea.wav"></audio> |
+| `aura-2-andromeda-en` | andromeda | feminine | Adult | en-us | American | Casual, Expressive, Comfortable | Customer service, IVR | <audio id="andromeda" controls src="https://static.deepgram.com/examples/Aura-2-andromeda.wav"></audio> |
+| `aura-2-apollo-en` | apollo | masculine | Adult | en-us | American | Confident, Comfortable, Casual | Casual chat | <audio id="apollo"  controls src="https://static.deepgram.com/examples/Aura-2-apollo.wav"></audio> |
+| `aura-2-arcas-en` | arcas | masculine | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas" controls src="https://static.deepgram.com/examples/Aura-2-arcas.wav"></audio> |
+| `aura-2-aries-en` | aries | masculine | Adult | en-us | American | Warm, Energetic, Caring | Casual chat | <audio id="aries"  controls src="https://static.deepgram.com/examples/Aura-2-aries.wav"></audio> |
+| `aura-2-asteria-en` | asteria | feminine | Adult | en-us | American | Clear, Confident, Knowledgeable, Energetic | Advertising | <audio id="asteria" controls src="https://static.deepgram.com/examples/Aura-2-asteria.wav"></audio> |
+| `aura-2-athena-en` | athena | feminine | Mature | en-us | American | Calm, Smooth, Professional | Storytelling | <audio id="athena"  controls src="https://static.deepgram.com/examples/Aura-2-athena.wav"></audio> |
+| `aura-2-atlas-en` | atlas | masculine | Mature | en-us | American | Enthusiastic, Confident, Approachable, Friendly | Advertising | <audio id="atlas"  controls src="https://static.deepgram.com/examples/Aura-2-atlas.wav"></audio> |
+| `aura-2-aurora-en` | aurora | feminine | Adult | en-us | American | Cheerful, Expressive, Energetic | Interview | <audio id="aurora"  controls src="https://static.deepgram.com/examples/Aura-2-aurora.wav"></audio> |
+| `aura-2-callista-en` | callista | feminine | Adult | en-us | American | Clear, Energetic, Professional, Smooth | IVR | <audio id="callista"  controls src="https://static.deepgram.com/examples/Aura-2-callista.wav"></audio> |
+| `aura-2-cora-en` | cora | feminine | Adult | en-us | American | Smooth, Melodic, Caring | Storytelling | <audio id="cora"  controls src="https://static.deepgram.com/examples/Aura-2-cora.wav"></audio> |
+| `aura-2-cordelia-en` | cordelia | feminine | Young Adult | en-us | American | Approachable, Warm, Polite | Storytelling | <audio id="cordelia"  controls src="https://static.deepgram.com/examples/Aura-2-cordelia.wav"></audio> |
+| `aura-2-delia-en` | delia | feminine | Young Adult | en-us | American | Casual, Friendly, Cheerful, Breathy | Interview | <audio id="delia"  controls src="https://static.deepgram.com/examples/Aura-2-delia.wav"></audio> |
+| `aura-2-draco-en` | draco | masculine | Adult | en-gb | British | Warm, Approachable, Trustworthy, Baritone | Storytelling | <audio id="draco"  controls src="https://static.deepgram.com/examples/Aura-2-draco.wav"></audio> |
+| `aura-2-electra-en` | electra | feminine | Adult | en-us | American | Professional, Engaging, Knowledgeable | IVR, advertising, customer service | <audio id="electra"  controls src="https://static.deepgram.com/examples/Aura-2-electra.wav"></audio> |
+| `aura-2-harmonia-en` | harmonia | feminine | Adult | en-us | American | Empathetic, Clear, Calm, Confident | Customer service | <audio id="harmonia"  controls src="https://static.deepgram.com/examples/Aura-2-harmonia.wav"></audio> |
+| `aura-2-helena-en` | helena | feminine | Adult | en-us | American | Caring, Natural, Positive, Friendly, Raspy | IVR, casual chat | <audio id="helena"  controls src="https://static.deepgram.com/examples/Aura-2-helena.wav"></audio> |
+| `aura-2-hera-en` | hera | feminine | Adult | en-us | American | Smooth, Warm, Professional | Informative | <audio id="hera"  controls src="https://static.deepgram.com/examples/Aura-2-hera.wav"></audio> |
+| `aura-2-hermes-en` | hermes | masculine | Adult | en-us | American | Expressive, Engaging, Professional | Informative | <audio id="hermes"  controls src="https://static.deepgram.com/examples/Aura-2-hermes.wav"></audio> |
+| `aura-2-hyperion-en` | hyperion | masculine | Adult | en-au | Australian | Caring, Warm, Empathetic | Interview | <audio id="hyperion"  controls src="https://static.deepgram.com/examples/Aura-2-hyperion.wav"></audio> |
+| `aura-2-iris-en` | iris | feminine | Young Adult | en-us | American | Cheerful, Positive, Approachable | IVR, advertising, customer service | <audio id="iris"  controls src="https://static.deepgram.com/examples/Aura-2-iris.wav"></audio> |
+| `aura-2-janus-en` | janus | feminine | Adult | en-us | American | Southern, Smooth, Trustworthy | Storytelling | <audio id="janus"  controls src="https://static.deepgram.com/examples/Aura-2-janus.wav"></audio> |
+| `aura-2-juno-en` | juno | feminine | Adult | en-us | American | Natural, Engaging, Melodic, Breathy | Interview | <audio id="juno"  controls src="https://static.deepgram.com/examples/Aura-2-juno.wav"></audio> |
+| `aura-2-jupiter-en` | jupiter | masculine | Adult | en-us | American | Expressive, Knowledgeable, Baritone | Informative | <audio id="jupiter"  controls src="https://static.deepgram.com/examples/Aura-2-jupiter.wav"></audio> |
+| `aura-2-luna-en` | luna | feminine | Young Adult | en-us | American | Friendly, Natural, Engaging | IVR | <audio id="luna"  controls src="https://static.deepgram.com/examples/Aura-2-luna.wav"></audio> |
+| `aura-2-mars-en` | mars | masculine | Adult | en-us | American | Smooth, Patient, Trustworthy, Baritone | Customer service | <audio id="mars"  controls src="https://static.deepgram.com/examples/Aura-2-mars.wav"></audio> |
+| `aura-2-minerva-en` | minerva | feminine | Adult | en-us | American | Positive, Friendly, Natural | Storytelling | <audio id="minerva"  controls src="https://static.deepgram.com/examples/Aura-2-minerva.wav"></audio> |
+| `aura-2-neptune-en` | neptune | masculine | Adult | en-us | American | Professional, Patient, Polite | Customer service | <audio id="neptune"  controls src="https://static.deepgram.com/examples/Aura-2-neptune.wav"></audio> |
+| `aura-2-odysseus-en` | odysseus | masculine | Adult | en-us | American | Calm, Smooth, Comfortable, Professional | Advertising | <audio id="odysseus"  controls src="https://static.deepgram.com/examples/Aura-2-odysseus.wav"></audio> |
+| `aura-2-ophelia-en` | ophelia | feminine | Adult | en-us | American | Expressive, Enthusiastic, Cheerful | Interview | <audio id="ophelia"  controls src="https://static.deepgram.com/examples/Aura-2-ophelia.wav"></audio> |
+| `aura-2-orion-en` | orion | masculine | Adult | en-us | American | Approachable, Comfortable, Calm, Polite | Informative | <audio id="orion"  controls src="https://static.deepgram.com/examples/Aura-2-orion.wav"></audio> |
+| `aura-2-orpheus-en` | orpheus | masculine | Adult | en-us | American | Professional, Clear, Confident, Trustworthy | Customer service, storytelling | <audio id="orpheus"  controls src="https://static.deepgram.com/examples/Aura-2-orpheus.wav"></audio> |
+| `aura-2-pandora-en` | pandora | feminine | Adult | en-gb | British | Smooth, Calm, Melodic, Breathy | IVR, informative | <audio id="pandora"  controls src="https://static.deepgram.com/examples/Aura-2-pandora.wav"></audio> |
+| `aura-2-phoebe-en` | phoebe | feminine | Adult | en-us | American | Energetic, Warm, Casual | Customer service | <audio id="phoebe"  controls src="https://static.deepgram.com/examples/Aura-2-phoebe.wav"></audio> |
+| `aura-2-pluto-en` | pluto | masculine | Adult | en-us | American | Smooth, Calm, Empathetic, Baritone | Interview, storytelling | <audio id="pluto"  controls src="https://static.deepgram.com/examples/Aura-2-pluto.wav"></audio> |
+| `aura-2-saturn-en` | saturn | masculine | Adult | en-us | American | Knowledgeable, Confident, Baritone | Customer service | <audio id="saturn"  controls src="https://static.deepgram.com/examples/Aura-2-saturn.wav"></audio> |
+| `aura-2-selene-en` | selene | feminine | Adult | en-us | American | Expressive, Engaging, Energetic | Informative | <audio id="selene"  controls src="https://static.deepgram.com/examples/Aura-2-selene.wav"></audio> |
+| `aura-2-thalia-en` | thalia | feminine | Adult | en-us | American | Clear, Confident, Energetic, Enthusiastic | Casual chat, customer service, IVR | <audio id="thalia"  controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
+| `aura-2-theia-en` | theia | feminine | Adult | en-au | American | Expressive, Polite, Sincere | Informative | <audio id="theia"  controls src="https://static.deepgram.com/examples/Aura-2-theia.wav"></audio> |
+| `aura-2-vesta-en` | vesta | feminine | Adult | en-us | American | Natural, Expressive, Patient, Empathetic | Customer service, interview, storytelling | <audio id="vesta"  controls src="https://static.deepgram.com/examples/Aura-2-vesta.wav"></audio> |
+| `aura-2-zeus-en` | zeus | masculine | Adult | en-us | American | Deep, Trustworthy, Smooth | IVR | <audio id="zeus"  controls src="https://static.deepgram.com/examples/Aura-2-zeus.wav"></audio> |
+
+</div>
 
 ## Aura 1: All Available Voices
 
-| model | name | expressed gender | age | accent | language | characteristics | use cases | audio sample |
-| :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
-| `aura-asteria-en` | asteria | female | Adult | en-us | American | Clear, Confident, Knowledgeable, Energetic | Advertising | <audio id="asteria" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565353/aura/asteria_docs_venw0r.wav"></audio> |
-| `aura-luna-en` | luna | female | Young Adult | en-us | American | Friendly, Natural, Engaging | IVR | <audio id="luna" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565351/aura/luna_docs_clom0e.wav"></audio> |
-| `aura-stella-en` | stella | female | Adult | en-us | American | Clear, Professional, Engaging | Customer service | <audio id="stella" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565349/aura/stella_docs_xh5jbv.wav"></audio> |
-| `aura-athena-en` | athena | female | Mature | en-gb | British | Calm, Smooth, Professional | Storytelling | <audio id="athena" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565613/aura/athena_docs_wyznud.wav"></audio> |
-| `aura-hera-en` | hera | female | Adult | en-us | American | Smooth, Warm, Professional | Informative | <audio id="hera" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565347/aura/hera_docs_xjkt4x.wav"></audio> |
-| `aura-orion-en` | orion | male | Adult | en-us | American | Approachable, Comfortable, Calm, Polite | Informative | <audio id="orion" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565346/aura/orion_docs_aljv1q.mp3"></audio> |
-| `aura-arcas-en` | arcas | male | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565348/aura/arcas_docs_pc9hxp.mp3"></audio> |
-| `aura-perseus-en` | perseus | male | Adult | en-us | American | Confident, Professional, Clear | Customer service | <audio id="perseus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565350/aura/perseus_docs_ap7fc0.wav"></audio> |
-| `aura-angus-en` | angus | male | Adult | en-ie | Irish | Warm, Friendly, Natural | Storytelling | <audio id="angus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565352/aura/angus_docs_lgse2b.wav"></audio> |
-| `aura-orpheus-en` | orpheus | male | Adult | en-us | American | Professional, Clear, Confident, Trustworthy | Customer service, storytelling | <audio id="orpheus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565350/aura/orpheus_docs_zdlpcf.wav"></audio> |
-| `aura-helios-en` | helios | male | Adult | en-gb | British | Professional, Clear, Confident | Customer service | <audio id="helios" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565346/aura/helios_docs_ycjwoo.wav"></audio> |
-| `aura-zeus-en` | zeus | male | Adult | en-us | American | Deep, Trustworthy, Smooth | IVR | <audio id="zeus" style="width:188px;" controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565347/aura/zeus_docs_fupdiv.wav"></audio> |
+<div className="voice-model-table">
 
-<Info>
-  We'd love to get your feedback on Deepgram's Aura Text-to-Speech voice models. Let us know which languages you need by [completing this survey.](https://deepgram.typeform.com/aura-languages)
-</Info>
+| Model | Name | Expressed Gender | Age | Accent | Language | Characteristics | Use Cases | Sample |
+| :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
+| `aura-asteria-en` | asteria | feminine | Adult | en-us | American | Clear, Confident, Knowledgeable, Energetic | Advertising | <audio id="asteria"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565353/aura/asteria_docs_venw0r.wav"></audio> |
+| `aura-luna-en` | luna | feminine | Young Adult | en-us | American | Friendly, Natural, Engaging | IVR | <audio id="luna"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565351/aura/luna_docs_clom0e.wav"></audio> |
+| `aura-stella-en` | stella | feminine | Adult | en-us | American | Clear, Professional, Engaging | Customer service | <audio id="stella"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565349/aura/stella_docs_xh5jbv.wav"></audio> |
+| `aura-athena-en` | athena | feminine | Mature | en-gb | British | Calm, Smooth, Professional | Storytelling | <audio id="athena"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565613/aura/athena_docs_wyznud.wav"></audio> |
+| `aura-hera-en` | hera | feminine | Adult | en-us | American | Smooth, Warm, Professional | Informative | <audio id="hera"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565347/aura/hera_docs_xjkt4x.wav"></audio> |
+| `aura-orion-en` | orion | masculine | Adult | en-us | American | Approachable, Comfortable, Calm, Polite | Informative | <audio id="orion"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565346/aura/orion_docs_aljv1q.mp3"></audio> |
+| `aura-arcas-en` | arcas | masculine | Adult | en-us | American | Natural, Smooth, Clear, Comfortable | Customer service, casual chat | <audio id="arcas"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565348/aura/arcas_docs_pc9hxp.mp3"></audio> |
+| `aura-perseus-en` | perseus | masculine | Adult | en-us | American | Confident, Professional, Clear | Customer service | <audio id="perseus"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565350/aura/perseus_docs_ap7fc0.wav"></audio> |
+| `aura-angus-en` | angus | masculine | Adult | en-ie | Irish | Warm, Friendly, Natural | Storytelling | <audio id="angus"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565352/aura/angus_docs_lgse2b.wav"></audio> |
+| `aura-orpheus-en` | orpheus | masculine | Adult | en-us | American | Professional, Clear, Confident, Trustworthy | Customer service, storytelling | <audio id="orpheus"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565350/aura/orpheus_docs_zdlpcf.wav"></audio> |
+| `aura-helios-en` | helios | masculine | Adult | en-gb | British | Professional, Clear, Confident | Customer service | <audio id="helios"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565346/aura/helios_docs_ycjwoo.wav"></audio> |
+| `aura-zeus-en` | zeus | masculine | Adult | en-us | American | Deep, Trustworthy, Smooth | IVR | <audio id="zeus"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565347/aura/zeus_docs_fupdiv.wav"></audio> |
+
+</div>
 
 ***

--- a/fern/docs/tts-models.mdx
+++ b/fern/docs/tts-models.mdx
@@ -38,7 +38,7 @@ These are our featured voices, selected for their versatility and quality:
 
 <div className="voice-model-table">
 
-| Model | Name | Expressed Gender | Age | Accent | Language | Characteristics | Use Cases | Sample|
+| Model | Name | Expressed Gender | Age | Language | Accent | Characteristics | Use Cases | Sample|
 | :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
 | `aura-2-thalia-en` | thalia | feminine | Adult | en-us | American | Clear, Confident, Energetic, Enthusiastic | Casual chat, customer service, IVR | <audio id="thalia"  controls src="https://static.deepgram.com/examples/Aura-2-thalia.wav"></audio> |
 | `aura-2-andromeda-en` | andromeda | feminine | Adult | en-us | American | Casual, Expressive, Comfortable | Customer service, IVR | <audio id="andromeda"  controls src="https://static.deepgram.com/examples/Aura-2-andromeda.wav"></audio> |
@@ -53,7 +53,7 @@ These are our featured voices, selected for their versatility and quality:
 
 <div className="voice-model-table">
 
-| Model | Name | Expressed Gender | Age | Accent | Language | Characteristics | Use Cases | Sample |
+| Model | Name | Expressed Gender | Age | Language | Accent | Characteristics | Use Cases | Sample |
 | :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
 | `aura-2-amalthea-en` | amalthea | feminine | Young Adult | en-ph | Filipino | Engaging, Natural, Cheerful | Casual chat | <audio id="amalthea" controls src="https://static.deepgram.com/examples/Aura-2-amalthea.wav"></audio> |
 | `aura-2-andromeda-en` | andromeda | feminine | Adult | en-us | American | Casual, Expressive, Comfortable | Customer service, IVR | <audio id="andromeda" controls src="https://static.deepgram.com/examples/Aura-2-andromeda.wav"></audio> |
@@ -103,7 +103,7 @@ These are our featured voices, selected for their versatility and quality:
 
 <div className="voice-model-table">
 
-| Model | Name | Expressed Gender | Age | Accent | Language | Characteristics | Use Cases | Sample |
+| Model | Name | Expressed Gender | Age | Language | Accent | Characteristics | Use Cases | Sample |
 | :---- | :--- | :----- | :-- | :----- | :------- | :------------- | :-------- | :----------- |
 | `aura-asteria-en` | asteria | feminine | Adult | en-us | American | Clear, Confident, Knowledgeable, Energetic | Advertising | <audio id="asteria"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565353/aura/asteria_docs_venw0r.wav"></audio> |
 | `aura-luna-en` | luna | feminine | Young Adult | en-us | American | Friendly, Natural, Engaging | IVR | <audio id="luna"  controls src="https://res.cloudinary.com/deepgram/video/upload/v1709565351/aura/luna_docs_clom0e.wav"></audio> |

--- a/fern/docs/tts-rest.mdx
+++ b/fern/docs/tts-rest.mdx
@@ -16,6 +16,6 @@ To begin using Deepgram's Text-to-Speech REST interface, there are several pages
 * [Getting Started](/docs/text-to-speech)
 * [Feature Overview](/docs/tts-feature-overview)
 * [Starter Apps](/docs/tts-starter-apps)
-* [API Reference](/docs/text-to-speech-api)
+* [API Reference](/reference/text-to-speech-api/speak)
 
 ***

--- a/fern/docs/tts-sample-rate.mdx
+++ b/fern/docs/tts-sample-rate.mdx
@@ -30,16 +30,19 @@ You can use the following cURL command in a terminal or your favorite API client
 <CodeGroup>
   ```bash cURL
   curl --request POST \
-       --url "https://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=linear16&sample_rate=24000" \
+       --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=linear16&sample_rate=24000" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --header 'Content-Type: application/json' \
+       --data '{"text": "Hello, how can I help you today?"}' \
        --output sample_rate_24000.wav \
-       --data '{"text": "Hello, how can I help you today?"}'
        --fail-with-body \
-       --silent \
-       || (jq . sample_rate_24000.wav && rm sample_rate_24000.wav)
+       --silent || echo "Request failed"
   ```
 </CodeGroup>
+
+<Warning>
+  Replace `YOUR_DEEPGRAM_API_KEY` with your [Deepgram API Key](/docs/create-additional-api-keys).
+</Warning>
 
 ### Query Parameters
 
@@ -83,9 +86,3 @@ This includes:
 * `dg-model-name`: The name of the model used to process the request.
 * `transfer-encoding`: Specifies the form of encoding used to safely transfer the payload to the recipient.
 * `date`: The date and time the response was sent.
-
-## API Error Responses
-
-<Info>
-  For information on Deepgram's error messages and error codes, read the API Reference [Errors](/reference/errors) page.
-</Info>

--- a/fern/docs/tts-sample-rate.mdx
+++ b/fern/docs/tts-sample-rate.mdx
@@ -64,7 +64,7 @@ Upon successful processing of the request, you will receive an audio file contai
   ```text http
   HTTP/1.1 200 OK
   < content-type: audio/mpeg
-  < dg-model-name: aura-asteria-en
+  < dg-model-name: aura-2-thalia-en
   < dg-model-uuid: e4979ab0-8475-4901-9d66-0a562a4949bb
   < dg-char-count: 32
   < dg-request-id: bf6fc5c7-8f84-479f-b70a-602cf5bf18f3

--- a/fern/docs/tts-starter-apps.mdx
+++ b/fern/docs/tts-starter-apps.mdx
@@ -7,27 +7,27 @@ slug: docs/tts-starter-apps
 ---
 
 
-# Text To Speech REST
+## Text To Speech REST
 
 <CardGroup cols={3}>
 <Card title="" href="https://github.com/deepgram-starters/text-to-speech-starter-node">
   <img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/deepgram/js-green.svg" width="5rem" height="5rem"/>
-  
-  
+
+
   Node.js Starter
 </Card>
 
 <Card title="" href="https://github.com/deepgram-starters/text-to-speech-starter-python">
   <img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/deepgram/flask.svg" width="5rem" height="5rem" class="invert-white"/>
-  
-  
+
+
   Flask Starter
 </Card>
 
 <Card title="" href="https://github.com/deepgram-starters/text-to-speech-starter-go">
   <img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/deepgram/go.svg" width="5rem" height="5rem"/>
-  
-  
+
+
   Go Starter
 </Card>
 </CardGroup>
@@ -37,36 +37,36 @@ slug: docs/tts-starter-apps
 <CardGroup cols={3}>
 <Card title="" href="https://github.com/deepgram-starters/node-live-text-to-speech">
   <img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/deepgram/js-green.svg" width="5rem" height="5rem"/>
-  
-  
+
+
   Node.js Starter
 </Card>
 
 <Card title="" href="https://github.com/deepgram-starters/flask-live-text-to-speech">
   <img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/deepgram/flask.svg" width="5rem" height="5rem" class="invert-white"/>
-  
-  
+
+
   Flask Starter
 </Card>
 
 <Card title="" href="https://github.com/deepgram-starters/flask-chatgpt-live-text-to-speech">
   <img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/deepgram/flask.svg" width="5rem" height="5rem" class="invert-white"/>
-  
-  
+
+
   Flask + Chat GPT Starter
 </Card>
 
 <Card title="" href="https://github.com/deepgram-starters/go-live-text-to-speech">
   <img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/deepgram/go.svg" width="5rem" height="5rem"/>
-  
-  
+
+
   Go Starter
 </Card>
 
 <Card title="" href="https://github.com/deepgram-starters/dotnet-live-text-to-speech">
   <img src="https://fern-image-hosting.s3.us-east-1.amazonaws.com/deepgram/net.svg" width="5rem" height="5rem"/>
-  
-  
+
+
   .NET Starter
 </Card>
 </CardGroup>

--- a/fern/docs/twilio-and-deepgram-tts.mdx
+++ b/fern/docs/twilio-and-deepgram-tts.mdx
@@ -179,7 +179,7 @@ Next we have the `twilio_sender` task:
 <CodeGroup>
   ```python Python
           # make a Deepgram Aura TTS request specifying that we want raw mulaw audio as the output
-          url = 'https://api.deepgram.com/v1/speak?model=aura-asteria-en&encoding=mulaw&sample_rate=8000&container=none'
+          url = 'https://api.deepgram.com/v1/speak?model=aura-2-thalia-en&encoding=mulaw&sample_rate=8000&container=none'
           headers = {
               'Authorization': 'Token YOUR_DEEPGRAM_API_KEY',
               'Content-Type': 'application/json'

--- a/fern/docs/twilio-and-deepgram-voice-agent.mdx
+++ b/fern/docs/twilio-and-deepgram-voice-agent.mdx
@@ -209,7 +209,7 @@ Also included in `twilio_handler` is the [Setting Configuration](/docs/voice-age
                       "instructions": "You are a helpful car seller.",
                   },
                   "speak": {
-                    "model": "aura-asteria-en"
+                    "model": "aura-2-thalia-en"
                   },
               },
           }

--- a/fern/docs/voice-agent-settings-configuration.mdx
+++ b/fern/docs/voice-agent-settings-configuration.mdx
@@ -55,7 +55,7 @@ This example uses a very basic `SettingConfiguration` to establish a connection.
         // ... additional think options including instructions and functions available
       },
       "speak": {
-        "model": "aura-asteria-en"
+        "model": "aura-2-thalia-en"
       }
     }
     // ... additional top-level options including context available

--- a/fern/docs/voice-agent-tts-models.mdx
+++ b/fern/docs/voice-agent-tts-models.mdx
@@ -15,20 +15,21 @@ By default [Deepgram Text-to-Speech](/docs/tts-models) will be used with the Voi
 
 These are just some of our most popular TTS voices. For a complete list see the [TTS Models Documentation](/docs/tts-models) .
 
-| agent.speak.model | Gender |
-| ----------------- | ------ |
-| `aura-stella-en`  | Female |
-| `aura-asteria-en` | Female |
-| `aura-luna-en`    | Female |
-| `aura-arcas-en`   | Male   |
-
+| agent.speak.model | Expressed Gender |
+| ----------------- | ---------------- |
+| `aura-2-thalia-en`| Feminine |
+| `aura-2-andromeda-en` | Feminine |
+| `aura-2-helena-en` | Feminine |
+| `aura-2-apollo-en`    | Masculine |
+| `aura-2-arcas-en`   | Masculine   |
+| `aura-2-aries-en` | Masculine|
 ## Example
 
 <CodeGroup>
   ```json JSON
   {
     "speak": {
-      "model": "aura-asteria-en"
+      "model": "aura-2-thalia-en"
     }
   }
   ```

--- a/fern/docs/voice-agent.mdx
+++ b/fern/docs/voice-agent.mdx
@@ -46,8 +46,8 @@ Follow these steps to connect to Deepgram's Voice Agent API and enable real-time
 | Use Case                                                                    | Runtime / Language           | Repo                                                                                                                                          |
 | --------------------------------------------------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Voice agent basic demo   | Node, TypeScript, JavaScript | [Deepgram Voice Agent Demo](https://github.com/deepgram-devs/deepgram-voice-agent-demo)                                                       |
-| Voice agent medical assistant demo                                                    | Node, TypeScript, JavaScript        | [Deepgram Voice Agent Medical Assistant Demo](https://github.com/deepgram-devs/voice-agent-medical-assistant-demo)                                   
-| Voice agent demo with Twilio                              | Python                       | [Python Twilio > Voice Agent Demo](/docs/twilio-and-deepgram-voice-agent)                                                                     |                               
+| Voice agent medical assistant demo                                                    | Node, TypeScript, JavaScript        | [Deepgram Voice Agent Medical Assistant Demo](https://github.com/deepgram-devs/voice-agent-medical-assistant-demo)
+| Voice agent demo with Twilio                              | Python                       | [Python Twilio > Voice Agent Demo](/docs/twilio-and-deepgram-voice-agent)                                                                     |
 | Voice agent demo with text input    | Node, TypeScript, JavaScript | [Deepgram Conversational AI Demo](https://github.com/deepgram-devs/deepgram-ai-agent-demo)                                                    |
 | Voice agent with Azure Open AI Services | Python                       | [Deepgram Voice Agent with OpenAI Azure](https://github.com/deepgram-devs/voice-agent-azure-open-ai-services)                                 |
 | Voice agent API with Amazon Bedrock                          | JavaScript / HTML            | [Deepgram Voice Agent with Amazon Bedrock](https://catalog.us-east-1.prod.workshops.aws/workshops/318f009b-6147-46b2-a86c-0e4a52866016/en-US) |
@@ -238,10 +238,10 @@ Open your terminal, navigate to the location on your drive where you want to cre
         },
         agent: {
           listen: {
-            model: "nova-2",
+            model: "nova-3",
           },
           speak: {
-            model: "aura-asteria-en",
+            model: "aura-2-thalia-en",
           },
           think: {
             provider: {

--- a/fern/docs/voice-agent.mdx
+++ b/fern/docs/voice-agent.mdx
@@ -241,7 +241,7 @@ Open your terminal, navigate to the location on your drive where you want to cre
             model: "nova-3",
           },
           speak: {
-            model: "aura-2-thalia-en",
+            model: "aura-asteria-en",
           },
           think: {
             provider: {


### PR DESCRIPTION
REST ONLY Changes

- updates curl commands to not use jq library where applicable
- sets custom CSS for extra-large voice model table 
-  adds new aura-2 voice model tables with metadata columns
-  updates aura-1 voice model with same metadata columns
- refactors voice model table 
- sets aura-2-thalia-en in code samples
- updates all applicable tts docs
- makes some "quality of life" docs improvements
- removes excessive call outs
- moves aura-2 formatting doc from hidden docs


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209448048607279