### PR TITLE
chore: adds redirect for ephem auth url

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1296,7 +1296,8 @@ redirects:
     destination: /docs/text-chunking-for-tts-optimization
   - source: /docs/genesys-with-deepgram
     destination: /docs/genesys-deepgram-legacy
-
+  - source: /reference/ephemeral-auth-api/grant-token
+    destination: /reference/token-based-auth-api/grant-token
 analytics:
   gtm:
     container-id: ${GTM_CONTAINER_ID}


### PR DESCRIPTION
This URL was in the wild for a bit, so a redirect will help catch anyone who might have used it to hit this page.