### PR TITLE
Make the doc name clearer for the end user

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -366,7 +366,7 @@ navigation:
             path: docs/tts-sample-rate.mdx
       - section: Tips and Tricks
         contents:
-          - page: Improving Aura-2 Formatting
+          - page: Formatting text for Aura-2
             path: docs/improving-aura-2-formatting.mdx
           - page: Handling Audio Issues in Text To Speech
             path: docs/handling-audio-issues-in-text-to-speech.mdx

--- a/fern/docs/improving-aura-2-formatting.mdx
+++ b/fern/docs/improving-aura-2-formatting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Improving Aura-2 Formatting
+title: Formatting text for Aura-2
 subtitle: Optimize Aura-2 Text-to-Speech Generation Quality
 slug: docs/improving-aura-2-formatting
 description: "Formatting Text for Aura-2"

--- a/fern/docs/improving-aura-2-formatting.mdx
+++ b/fern/docs/improving-aura-2-formatting.mdx
@@ -2,7 +2,7 @@
 title: Formatting text for Aura-2
 subtitle: Optimize Aura-2 Text-to-Speech Generation Quality
 slug: docs/improving-aura-2-formatting
-description: "Formatting Text for Aura-2"
+description: "Optimize Aura-2 Text-to-Speech Generation Quality"
 ---
 
 <Warning>


### PR DESCRIPTION
Left the url paths to prevent breaking changes.