### PR TITLE
Updated rate limits for Aura-2. 

### DIFF
--- a/fern/docs/api-rate-limits.mdx
+++ b/fern/docs/api-rate-limits.mdx
@@ -31,8 +31,8 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 | Model                                                             | Service Limit                           |
 | :---------------------------------------------------------------- | :-------------------------------------- |
-| [Aura-1](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go: Up to 480 requests / min |
-| [Aura-1](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 720 requests / min       |
+| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go: Up to 480 requests / min |
+| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 720 requests / min       |
 | [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go:  Up to 5 requests / min       |
 | [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 5 requests / min       |
 
@@ -40,8 +40,8 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 | Model                                                             | Service Limit                               |
 | :---------------------------------------------------------------- | :------------------------------------------ |
-| [Aura-1](https://developers.deepgram.com/docs/streaming-text-to-speech) | Pay as You Go: Up to 40 concurrent requests |
-| [Aura-1](https://developers.deepgram.com/docs/streaming-text-to-speech) | Growth:  Up to 80 concurrent requests       |
+| [Aura](https://developers.deepgram.com/docs/streaming-text-to-speech) | Pay as You Go: Up to 40 concurrent requests |
+| [Aura](https://developers.deepgram.com/docs/streaming-text-to-speech) | Growth:  Up to 80 concurrent requests       |
 | [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | Pay as You Go: n/a |
 | [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | Growth:  n/a |
 <Warning>
@@ -101,14 +101,14 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 | Model                                                             | Service Limit                   | Feedback                                                                                   |
 | :---------------------------------------------------------------- | :------------------------------ | :----------------------------------------------------------------------------------------- |
-| [Aura-1](https://developers.deepgram.com/docs/text-to-speech) | Starting at 2400 requests / min | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
+| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Starting at 2400 requests / min | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
 | [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Starting at 5 requests / min | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
 
 ### Text to Speech Streaming
 
 | Model                                                                       | Service Limit                       | Feedback                                                                                   |
 | :-------------------------------------------------------------------------- | :---------------------------------- | :----------------------------------------------------------------------------------------- |
-| [Aura-1](https://developers.deepgram.com/docs/streaming-text-to-speech) | Starting at 150 concurrent requests | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
+| [Aura](https://developers.deepgram.com/docs/streaming-text-to-speech) | Starting at 150 concurrent requests | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
 | [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | n/a | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
 <Warning>
 Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.

--- a/fern/docs/api-rate-limits.mdx
+++ b/fern/docs/api-rate-limits.mdx
@@ -31,8 +31,8 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 | Model                                                             | Service Limit                           |
 | :---------------------------------------------------------------- | :-------------------------------------- |
-| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go: Up to 480 requests / min |
-| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 720 requests / min       |
+| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go: Up to 5 requests / min |
+| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 5 requests / min       |
 | [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go:  Up to 5 requests / min       |
 | [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 5 requests / min       |
 

--- a/fern/docs/api-rate-limits.mdx
+++ b/fern/docs/api-rate-limits.mdx
@@ -31,19 +31,20 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 | Model                                                             | Service Limit                           |
 | :---------------------------------------------------------------- | :-------------------------------------- |
-| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go: Up to 5 requests / min |
-| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 5 requests / min       |
-| [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go:  Up to 5 requests / min       |
-| [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 5 requests / min       |
+| [Aura](/docs/text-to-speech) | Pay as You Go: Up to 5 requests|
+| [Aura](/docs/text-to-speech) | Growth:  Up to 5 requests |
+| [Aura-2](/docs/text-to-speech) | Pay as You Go:  Up to 5 requests |
+| [Aura-2](/docs/text-to-speech) | Growth:  Up to 5 requests  |
 
 ### Text to Speech Streaming
 
 | Model                                                             | Service Limit                               |
 | :---------------------------------------------------------------- | :------------------------------------------ |
-| [Aura](https://developers.deepgram.com/docs/streaming-text-to-speech) | Pay as You Go: Up to 40 concurrent requests |
-| [Aura](https://developers.deepgram.com/docs/streaming-text-to-speech) | Growth:  Up to 80 concurrent requests       |
-| [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | Pay as You Go: n/a |
-| [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | Growth:  n/a |
+| [Aura](/docs/streaming-text-to-speech) | Pay as You Go: Up to 40 concurrent requests |
+| [Aura](/docs/streaming-text-to-speech) | Growth:  Up to 80 concurrent requests       |
+| [Aura-2](/docs/streaming-text-to-speech) | Pay as You Go: n/a |
+| [Aura-2](/docs/streaming-text-to-speech) | Growth:  n/a |
+
 <Warning>
 Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
 </Warning>
@@ -99,20 +100,23 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 ### Text to Speech REST
 
-| Model                                                             | Service Limit                   | Feedback                                                                                   |
-| :---------------------------------------------------------------- | :------------------------------ | :----------------------------------------------------------------------------------------- |
-| [Aura](https://developers.deepgram.com/docs/text-to-speech) | Starting at 2400 requests / min | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
-| [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Starting at 5 requests / min | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
+| Model                                                             | Service Limit                   |
+| :---------------------------------------------------------------- | :------------------------------ |
+| [Aura](/docs/text-to-speech) | Starting at 2400 requests / min |
+| [Aura-2](/docs/text-to-speech) | Starting at 5 requests / min |
 
 ### Text to Speech Streaming
 
-| Model                                                                       | Service Limit                       | Feedback                                                                                   |
-| :-------------------------------------------------------------------------- | :---------------------------------- | :----------------------------------------------------------------------------------------- |
-| [Aura](https://developers.deepgram.com/docs/streaming-text-to-speech) | Starting at 150 concurrent requests | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
-| [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | n/a | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
+| Model                                                                       | Service Limit                       |
+| :-------------------------------------------------------------------------- | :---------------------------------- |
+| [Aura](/docs/streaming-text-to-speech) | Starting at 150 concurrent requests |
+| [Aura-2](/docs/streaming-text-to-speech) | n/a |
+
+
 <Warning>
 Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
 </Warning>
+
 ### Audio Intelligence
 
 If you include Audio Intelligence features in requests to `/listen`, you will be subject to the service limits noted in the table below.
@@ -134,8 +138,7 @@ If you include Audio Intelligence features in requests to `/listen`, you will be
 | [Summarization](/docs/text-summarization)              | Starting at 10 concurrent requests |
 | [Topic Detection](/docs/text-topic-detection)          | Starting at 10 concurrent requests |
 
-<br />
 
 <Warning>
-The [error](https://developers.deepgram.com/reference/errors#429-rate-limit-exceeded-1) `429: Too Many Requests` is returned when your project has more concurrent requests than the rate limits allow. To learn more about this error please see our Documentation on [Errors](/reference/errors).
+The [error](/docs/errors#429-rate-limit-exceeded-1) `429: Too Many Requests` is returned when your project has more concurrent requests than the rate limits allow. To learn more about this error please see our Documentation on [Errors](/docs/errors).
 </Warning>

--- a/fern/docs/api-rate-limits.mdx
+++ b/fern/docs/api-rate-limits.mdx
@@ -31,15 +31,22 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 | Model                                                             | Service Limit                           |
 | :---------------------------------------------------------------- | :-------------------------------------- |
-| [Aura](https://developers.deepgram.com/docs/tts-feature-overview) | Pay as You Go: Up to 480 requests / min |
-| [Aura](https://developers.deepgram.com/docs/tts-feature-overview) | Growth:  Up to 720 requests / min       |
+| [Aura-1](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go: Up to 480 requests / min |
+| [Aura-1](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 720 requests / min       |
+| [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Pay as You Go:  Up to 5 requests / min       |
+| [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Growth:  Up to 5 requests / min       |
 
 ### Text to Speech Streaming
 
 | Model                                                             | Service Limit                               |
 | :---------------------------------------------------------------- | :------------------------------------------ |
-| [Aura](https://developers.deepgram.com/docs/tts-feature-overview) | Pay as You Go: Up to 40 concurrent requests |
-| [Aura](https://developers.deepgram.com/docs/tts-feature-overview) | Growth:  Up to 80 concurrent requests       |
+| [Aura-1](https://developers.deepgram.com/docs/streaming-text-to-speech) | Pay as You Go: Up to 40 concurrent requests |
+| [Aura-1](https://developers.deepgram.com/docs/streaming-text-to-speech) | Growth:  Up to 80 concurrent requests       |
+| [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | Pay as You Go: n/a |
+| [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | Growth:  n/a |
+<Warning>
+Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
+</Warning>
 
 ### Audio Intelligence
 
@@ -94,14 +101,18 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 | Model                                                             | Service Limit                   | Feedback                                                                                   |
 | :---------------------------------------------------------------- | :------------------------------ | :----------------------------------------------------------------------------------------- |
-| [Aura](https://developers.deepgram.com/docs/tts-feature-overview) | Starting at 2400 requests / min | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
+| [Aura-1](https://developers.deepgram.com/docs/text-to-speech) | Starting at 2400 requests / min | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
+| [Aura-2](https://developers.deepgram.com/docs/text-to-speech) | Starting at 5 requests / min | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
 
 ### Text to Speech Streaming
 
 | Model                                                                       | Service Limit                       | Feedback                                                                                   |
 | :-------------------------------------------------------------------------- | :---------------------------------- | :----------------------------------------------------------------------------------------- |
-| [Aura](https://developers.deepgram.com/docs/tts-streaming-feature-overview) | Starting at 150 concurrent requests | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
-
+| [Aura-1](https://developers.deepgram.com/docs/streaming-text-to-speech) | Starting at 150 concurrent requests | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
+| [Aura-2](https://developers.deepgram.com/docs/streaming-text-to-speech) | n/a | [Share your feedback on our TTS rate limits](https://deepgram.typeform.com/tts-rate-limit) |
+<Warning>
+Aura-2 is currently available for the [TTS REST API only](/reference/text-to-speech-api/speak). Websocket support is coming soon.
+</Warning>
 ### Audio Intelligence
 
 If you include Audio Intelligence features in requests to `/listen`, you will be subject to the service limits noted in the table below.

--- a/fern/docs/api-rate-limits.mdx
+++ b/fern/docs/api-rate-limits.mdx
@@ -31,10 +31,10 @@ If multiple services are used in one API call (e.g Speech to Text + Sentiment An
 
 | Model                                                             | Service Limit                           |
 | :---------------------------------------------------------------- | :-------------------------------------- |
-| [Aura](/docs/text-to-speech) | Pay as You Go: Up to 5 requests|
-| [Aura](/docs/text-to-speech) | Growth:  Up to 5 requests |
-| [Aura-2](/docs/text-to-speech) | Pay as You Go:  Up to 5 requests |
-| [Aura-2](/docs/text-to-speech) | Growth:  Up to 5 requests  |
+| [Aura](/docs/text-to-speech) | Pay as You Go: Up to 5 concurrent requests|
+| [Aura](/docs/text-to-speech) | Growth: Up to 5 concurrent requests |
+| [Aura-2](/docs/text-to-speech) | Pay as You Go: Up to 5 concurrent requests |
+| [Aura-2](/docs/text-to-speech) | Growth: Up to 5 concurrent requests  |
 
 ### Text to Speech Streaming
 


### PR DESCRIPTION
Changes include: renaming 'Aura' to 'Aura-1', pointing to the TTS REST and Streaming 'Getting Started' pages for all Aura-1 and Aura-2 links, adding warning messages about Aura-2 streaming not being supported, setting the rate limit for REST Aura-2 to 5 for PayGo/Growth and Enterprise.