### PR TITLE
chore:improves callout

### DIFF
--- a/fern/docs/authentication.mdx
+++ b/fern/docs/authentication.mdx
@@ -4,7 +4,7 @@ subtitle: Authenticating requests made to the Deepgram API
 ---
 
 <Info>
-  If you need to create short lived tokens for API requests, you can use the [Ephemeral Auth API](/reference/ephemeral-auth-api/grant-token).
+  If you need to create short lived tokens for `/Listen`, `/Speak`, or `/Read` API requests, you can use the [Token-based Auth API](/reference/token-based-auth-api/grant-token).
 </Info>
 
 Send requests to the API with an `Authorization` header that references your project's API Key:


### PR DESCRIPTION
- Clarifies call out and where short lived tokens can be used in terms of which APIs support them.