### PR TITLE
Update models-languages-overview.mdx with default language=en note

### DIFF
--- a/fern/docs/models-languages-overview.mdx
+++ b/fern/docs/models-languages-overview.mdx
@@ -16,6 +16,10 @@ slug: docs/models-languages-overview
 | [nova-3](/docs/models-languages-overview#nova-3) | Our highest performing model. Recommended for most use cases, especially audio with multiple languages, background noise, crosstalk and far field audio. |
 | [nova-2](/docs/models-languages-overview#nova-2) | Recommended for use cases with non-English transcription, and filler word identification.                                                                                                      |
 
+<Info>
+  All models default to `language=en` unless otherwise specified via the `language` parameter.
+</Info>
+
 ### Example
 
 To request any Deepgram Model, change `MODEL_OPTION` to the Model you want to use.


### PR DESCRIPTION
Answered a question on this today and realized it was a bit hard to find, so IMO better to note in models/lang overview page as well. Whoever reviews this -- I was also debating calling this out 'even with multi-lingual models' but decided this was cleaner. 