### PR TITLE
Always output ttfb for tts samples

### DIFF
--- a/fern/docs/text-to-speech-prompting.mdx
+++ b/fern/docs/text-to-speech-prompting.mdx
@@ -27,6 +27,7 @@ A comma (`,`) or a period (`.`) present in your text will be treated as a very *
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":"Hello, how can I help you today? ... Are you there ... Hello?"}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
@@ -62,6 +63,7 @@ Silent pauses are pauses that have a higher probability of staying silent in the
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":"To confirm, is your registration number BY. . 3984. . 0297?"}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
@@ -81,6 +83,7 @@ Filler words such as `um` and `uh` can also be used to offer a more natural soun
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":"Hello, how can I help you today? um Are you there uh Hello?"}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
@@ -102,6 +105,7 @@ While we do not offer pronunciation control as part of our API, you can create s
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":" To confirm, is your referral code Queue Why. Eigh Beee?"}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
@@ -127,6 +131,7 @@ You can add natural pauses between groups of 2 - 4 alphabets to include pauses.
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":" To confirm, is your referral code Queue Why. Eigh Beee?"}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
@@ -146,6 +151,7 @@ In most cases, acronyms can be handled by just providing the letters of the acro
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":"I love watching NBA Basketball."}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
@@ -167,6 +173,7 @@ Explicitly add the word `and` to tell the model to pronounce the entire phrase a
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":"The total is 1235, or twelve hundred and thirty-five."}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
@@ -190,6 +197,7 @@ If you are having trouble with words rooted in different languages in your text,
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":"I want to rahn-day-voo with you."}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```

--- a/fern/docs/text-to-speech.mdx
+++ b/fern/docs/text-to-speech.mdx
@@ -35,6 +35,7 @@ Next, try it with CURL. Add your own API key where it says `YOUR_DEEPGRAM_API_KE
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":"Hello, how can I help you today?"}' \
        --url "https://api.deepgram.com/v1/speak?model=aura-2-thalia-en"
   ```
@@ -70,6 +71,7 @@ This example will capture the error message using the [JQ](https://jqlang.org/) 
        --header "Content-Type: application/json" \
        --header "Authorization: Token DEEPGRAM_API_KEY" \
        --output your_output_file.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --data '{"text":"Hello, how can I help you today?"}' \
        --url 'https://api.deepgram.com/v1/speak?model=testing_error' \
        --fail-with-body \

--- a/fern/docs/tts-bit-rate.mdx
+++ b/fern/docs/tts-bit-rate.mdx
@@ -44,6 +44,7 @@ You can use the following cURL command in a terminal or your favorite API client
        --header 'Content-Type: application/json' \
        --data '{"text": "Hello, how can I help you today?"}' \
        --output outputfile_mp3_32000.mp3 \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --fail-with-body \
        --silent || echo "Request failed"
   ```

--- a/fern/docs/tts-container.mdx
+++ b/fern/docs/tts-container.mdx
@@ -47,6 +47,7 @@ You can use the following cURL command in a terminal or your favorite API client
        --header 'Content-Type: application/json' \
        --data '{"text": "Hello, how can I help you today?"}' \
        --output container_wav_output.wav \
+       --write-out "Time-to-First-Byte: %{time_starttransfer}s Time-to-Last-Byte: %{time_total}s\n" \
        --fail-with-body \
        --silent || echo "Request failed"
   ```


### PR DESCRIPTION
Context: https://deepgram.slack.com/archives/C066Y86ENQJ/p1745595132044839

People are being confused by what seems like high response times - what they see is the time-to-last-byte. Let's call that out in our cURL commands.

TODO: this notably doesn't touch anything related to our SDKs, so customers won't get any signals about TTFB vs TTLB when using the SDK. 