### PR TITLE
fixes self-hosted deploy in nav

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -801,9 +801,7 @@ navigation:
             path: docs/deepgram-unimrcp-plugin.mdx
       - page: Using SDKs with Self-Hosted
         path: docs/using-sdks-with-self-hosted.mdx
-
-  # THIS IS NOT VISIBLE IN THE NAV BAR
-  - tab: pages
+  - tab: pages # THIS IS NOT VISIBLE IN THE NAV BAR
     layout:
       - page: Support
         path: docs/support.mdx

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -19,7 +19,7 @@ logo:
   height: 32
   href: /
 
-navbar-links:                       
+navbar-links:
   - type: minimal
     text: "Playground"
     href: "https://playground.deepgram.com"
@@ -116,9 +116,7 @@ tabs:
   self-hosted:
     display-name: Self-Hosted Deployments
     slug: self-hosted
-
-  # THIS IS NOT VISIBLE IN THE NAV BAR
-  pages:
+  pages: # THIS IS NOT VISIBLE IN THE NAV BAR
     display-name: Pages
     slug: pages
     hidden: true


### PR DESCRIPTION
Self hosted deployments is only appearing locally at full size but not on the site consitently. the use of a comment lines might be the problem in docs.yml. 

this tests out that assumption

**LOCAL**

<img width="1641" alt="Screenshot 2025-05-14 at 10 13 11 PM" src="https://github.com/user-attachments/assets/290d3884-ec0e-4122-81df-8e40462d5a33" />

**SITE**

<img width="1312" alt="Screenshot 2025-05-14 at 10 25 46 PM" src="https://github.com/user-attachments/assets/cb396511-2389-45c4-a76b-cc80cc91e5e0" />

