### PR TITLE
Adds context_length content

### DIFF
--- a/fern/docs/configure-voice-agent.mdx
+++ b/fern/docs/configure-voice-agent.mdx
@@ -66,11 +66,9 @@ The `Settings` message is a JSON object that contains the following fields:
 
 #### `agent.think.context_length`
 
-* Only configurable when a custom think endpoint is used.
-* Use `Max` for maximum context length. This will set the context length to the maximum allowed based on the LLM provider you use.
+* Using `Max` will set the context length to the maximum allowed based on the LLM provider you use. If the total context exceeds the model's maximum, truncation is handled by the LLM provider.
 * Increasing the context length may help preserve multi-turn conversation history, especially when verbose function calls inflate the total context.
 * All characters sent to the LLM count toward the context limit, including fully serialized JSON messages, function call arguments, and responses. System messages are excluded and managed separately via `agent.think.prompt`.
-* The Voice Agent API does not enforce the LLM's context window. If the total context exceeds the model's maximum, truncation is handled by the LLM provider.
 * The default context length set by Deepgram is optimized for cost and latency. It is not recommended to change this setting unless there's a clear need.
 
 

--- a/fern/docs/configure-voice-agent.mdx
+++ b/fern/docs/configure-voice-agent.mdx
@@ -52,6 +52,7 @@ The `Settings` message is a JSON object that contains the following fields:
 | `agent.think.functions` | Array | Array of functions the agent can call during the conversation |
 | `agent.think.functions.endpoint` | Object | The Function endpoint to call. if not passed, function is called client-side |
 | `agent.think.prompt` | String | The system prompt that defines the agent's behavior and personality |
+| `agent.think.context_length` | Integer or String | Specifies the number of characters retained in context between user messages, agent responses, and function calls. This setting is only configurable when a custom think endpoint is used. Use `Max` for maximum context length. |
 | `agent.speak.provider.type` | Object | The [TTS Model](/docs/voice-agent-tts-models) provider type. e.g., `deepgram`, `eleven_labs`, `cartesia`, `open_ai` |
 | `agent.speak.provider.model` | String | The [TTS Model](/docs/voice-agent-tts-models)  to use for Deepgram or OpenAI |
 | `agent.speak.provider.model_id` | String| The [TTS Model](/docs/voice-agent-tts-models) ID to use for Eleven Labs or Cartesia |
@@ -107,6 +108,7 @@ Below is an in-depth example showing all the available fields for `Settings` wit
           }
         },
         "prompt": "You are a helpful AI assistant focused on customer service.",
+        "context_length": 1000,  // Optional and can only when a custom think endpoint is used. Use max for maximum context length
         "functions": [
           {
             "name": "check_order_status",

--- a/fern/docs/configure-voice-agent.mdx
+++ b/fern/docs/configure-voice-agent.mdx
@@ -108,7 +108,7 @@ Below is an in-depth example showing all the available fields for `Settings` wit
           }
         },
         "prompt": "You are a helpful AI assistant focused on customer service.",
-        "context_length": 1000,  // Optional and can only when a custom think endpoint is used. Use max for maximum context length
+        "context_length": 1000,  // Optional and can only be used when a custom think endpoint is used. Use max for maximum context length
         "functions": [
           {
             "name": "check_order_status",

--- a/fern/docs/configure-voice-agent.mdx
+++ b/fern/docs/configure-voice-agent.mdx
@@ -64,6 +64,16 @@ The `Settings` message is a JSON object that contains the following fields:
 | `agent.speak.endpoint` | Object | Optional if TTS provider is Deepgram. Required for non-Deepgram TTS providers. When present, must include `url` field and `headers` object |
 | `agent.greeting` | String | Optional initial message that the agent will speak when the conversation starts |
 
+#### `agent.think.context_length`
+
+* Only configurable when a custom think endpoint is used.
+* Use `Max` for maximum context length. This will set the context length to the maximum allowed based on the LLM provider you use.
+* Increasing the context length may help preserve multi-turn conversation history, especially when verbose function calls inflate the total context.
+* All characters sent to the LLM count toward the context limit, including fully serialized JSON messages, function call arguments, and responses. System messages are excluded and managed separately via `agent.think.prompt`.
+* The Voice Agent API does not enforce the LLM's context window. If the total context exceeds the model's maximum, truncation is handled by the LLM provider.
+* The default context length set by Deepgram is optimized for cost and latency. It is not recommended to change this setting unless there's a clear need.
+
+
 ## Full Example
 
 Below is an in-depth example showing all the available fields for `Settings` with all the optional fields for individual provider specific settings.
@@ -108,7 +118,7 @@ Below is an in-depth example showing all the available fields for `Settings` wit
           }
         },
         "prompt": "You are a helpful AI assistant focused on customer service.",
-        "context_length": 1000,  // Optional and can only be used when a custom think endpoint is used. Use max for maximum context length
+        "context_length": 15000,  // Optional and can only be used when a custom think endpoint is used. Use max for maximum context length
         "functions": [
           {
             "name": "check_order_status",

--- a/fern/docs/voice-agent-settings.mdx
+++ b/fern/docs/voice-agent-settings.mdx
@@ -57,7 +57,7 @@ This example uses a very basic `Settings` to establish a connection. To send the
         "temperature": 0.7
         // ... additional provider options: endpoint (for non-deepgram providers)
       },
-      // ... additional think options: prompt, functions, endpoint
+      // ... additional think options: prompt, context_length, functions, endpoint
     },
     "speak": {
       "provider": {


### PR DESCRIPTION
- updates Docs for context length 
- relates to https://github.com/deepgram/internal-api-specs/pull/112

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210403316564378