### PR TITLE
Reflect that agent supports token-based auth

### DIFF
--- a/fern/pages/guides/fundamentals/token-based-authentication.mdx
+++ b/fern/pages/guides/fundamentals/token-based-authentication.mdx
@@ -109,11 +109,11 @@ Temporary tokens have usage::write permission for these Deepgram APIs:
 - [`/speak` REST API](/reference/text-to-speech-api/speak) - Text to Speech
 - [`/speak` WebSocket API](/reference/text-to-speech-api/speak-streaming) - Text to Speech
 - [`/read` REST API](/reference/text-intelligence-api/text-read) - Text Intelligence
+- [`/agent` WebSocket API](/reference/voice-agent-api/agent) - Voice Agent
 
 These APIs will not work with temporary tokens:
 
 - The collection of [Management APIs](/reference/deepgram-api-overview)
-- The [`/agent` API](/reference/voice-agent-api/agent) - Coming soon!
 
 ### Can I use this token for speech-to-text pre-recorded requests?
 


### PR DESCRIPTION
Small copy change to reflect that this is now supported