### PR TITLE
fix: correct casing for context length "max" value

### DIFF
--- a/fern/docs/configure-voice-agent.mdx
+++ b/fern/docs/configure-voice-agent.mdx
@@ -52,7 +52,7 @@ The `Settings` message is a JSON object that contains the following fields:
 | `agent.think.functions` | Array | Array of functions the agent can call during the conversation |
 | `agent.think.functions.endpoint` | Object | The Function endpoint to call. if not passed, function is called client-side |
 | `agent.think.prompt` | String | The system prompt that defines the agent's behavior and personality |
-| `agent.think.context_length` | Integer or String | Specifies the number of characters retained in context between user messages, agent responses, and function calls. This setting is only configurable when a custom think endpoint is used. Use `Max` for maximum context length. |
+| `agent.think.context_length` | Integer or String | Specifies the number of characters retained in context between user messages, agent responses, and function calls. This setting is only configurable when a custom think endpoint is used. Use `max` for maximum context length. |
 | `agent.speak.provider.type` | Object | The [TTS Model](/docs/voice-agent-tts-models) provider type. e.g., `deepgram`, `eleven_labs`, `cartesia`, `open_ai` |
 | `agent.speak.provider.model` | String | The [TTS Model](/docs/voice-agent-tts-models)  to use for Deepgram or OpenAI |
 | `agent.speak.provider.model_id` | String| The [TTS Model](/docs/voice-agent-tts-models) ID to use for Eleven Labs or Cartesia |
@@ -73,7 +73,7 @@ The `Settings` message is a JSON object that contains the following fields:
 
 #### `agent.think.context_length`
 
-* Using `Max` will set the context length to the maximum allowed based on the LLM provider you use. If the total context exceeds the model's maximum, truncation is handled by the LLM provider.
+* Using `max` will set the context length to the maximum allowed based on the LLM provider you use. If the total context exceeds the model's maximum, truncation is handled by the LLM provider.
 * Increasing the context length may help preserve multi-turn conversation history, especially when verbose function calls inflate the total context.
 * All characters sent to the LLM count toward the context limit, including fully serialized JSON messages, function call arguments, and responses. System messages are excluded and managed separately via `agent.think.prompt`.
 * The default context length set by Deepgram is optimized for cost and latency. It is not recommended to change this setting unless there's a clear need.


### PR DESCRIPTION
This is indicated as lowercase in the spec. `max`, not `Max`.