### PR TITLE
Update profanity-filter.mdx

### DIFF
--- a/fern/docs/profanity-filter.mdx
+++ b/fern/docs/profanity-filter.mdx
@@ -16,8 +16,19 @@ slug: docs/profanity-filter
 `profanity_filter` *boolean* Default: `false`
 
 <div class="flex flex-row gap-2">
-  <Markdown src="../snippets/stt-batch-available.mdx" /> <Markdown src="../snippets/stt-stream-available.mdx" /> <Markdown src="../snippets/english.mdx" />
+  <Markdown src="../snippets/stt-batch-available.mdx" /> <Markdown src="../snippets/stt-stream-available.mdx" /> <Markdown src="../snippets/specific-languages-only.mdx" />
 </div>
+
+Deepgram’s profanity filtering feature will mask offensive language in transcripts. This feature is available for both English and select non-English languages.
+
+Supported languages include:
+
+- English: `en`, `en-US`, `en-AU`, `en-GB`, `en-NZ`, `en-IN`
+- German: `de`
+- Polish: `pl`
+- Portuguese: `pt`, `pt-BR`, `pt-PT`
+- Spanish: `es`, `es-419`
+- Swedish: `sv`, `sv-SE`
 
 ## Enable Feature
 

--- a/fern/docs/profanity-filter.mdx
+++ b/fern/docs/profanity-filter.mdx
@@ -25,6 +25,7 @@ Supported languages include:
 
 - English: `en`, `en-US`, `en-AU`, `en-GB`, `en-NZ`, `en-IN`
 - German: `de`
+- Swiss German: `gsw`
 - Polish: `pl`
 - Portuguese: `pt`, `pt-BR`, `pt-PT`
 - Spanish: `es`, `es-419`


### PR DESCRIPTION
updating docs w addition of non-english profanity filtering for the following languages (Nova-2 monolingual): Latin-American Spanish (es -- use es list for any language code starting with es, including es-419) German (de)
Swiss German (gsw -- this doesn't exist in the profanity repo, AI genned list) Portuguese (pt -- use pt list for any language code starting with pt, including pt/pt-br/pt-pt) Polish (pl)
Swedish (sv)