### PR TITLE
fixed issue with model parameters not matching api spec in python

### DIFF
--- a/fern/docs/voice-agent.mdx
+++ b/fern/docs/voice-agent.mdx
@@ -380,9 +380,9 @@ Next you will need to set up a very simplified version of the [Settings](/docs/v
         # Agent configuration
         options.agent.language = "en"
         options.agent.listen.provider.type = "deepgram"
-        options.agent.listen.model = "nova-3"
+        options.agent.listen.provider.model = "nova-3"
         options.agent.think.provider.type = "open_ai"
-        options.agent.think.model = "gpt-4o-mini"
+        options.agent.think.provider.model = "gpt-4o-mini"
         options.agent.think.prompt = "You are a friendly AI assistant."
         options.agent.speak.provider.type = "deepgram"
         options.agent.speak.model = "aura-2-thalia-en"
@@ -1488,12 +1488,12 @@ def main():
         # Agent configuration
         options.agent.language = "en"
         options.agent.listen.provider.type = "deepgram"
-        options.agent.listen.model = "nova-3"
+        options.agent.listen.provider.model = "nova-3"
         options.agent.think.provider.type = "open_ai"
-        options.agent.think.model = "gpt-4o-mini"
+        options.agent.think.provider.model = "gpt-4o-mini"
         options.agent.think.prompt = "You are a friendly AI assistant."
         options.agent.speak.provider.type = "deepgram"
-        options.agent.speak.model = "aura-2-thalia-en"
+        options.agent.speak.provider.model = "aura-2-thalia-en"
         options.agent.greeting = "Hello! How can I help you today?"
 
         # Send Keep Alive messages


### PR DESCRIPTION
The quick start tutorial for the voice agent is broken in Python. The way models are defined doesn't match the [API spec](https://developers.deepgram.com/reference/voice-agent-api/agent)

