### PR TITLE
removes mention of multi support

### DIFF
--- a/fern/docs/configure-voice-agent.mdx
+++ b/fern/docs/configure-voice-agent.mdx
@@ -69,7 +69,7 @@ The `Settings` message is a JSON object that contains the following fields:
 * Choose your language setting based on your use case:
   - If you know your input language, specify it directly for the best recognition accuracy.
   - If you expect multiple languages or are unsure, use `multi` for flexible language support.
-  - Currently `multi` is only supported with [Eleven Labs TTS](/docs/voice-agent-tts-models#eleven-labs)
+  - Currently `multi` is only supported with [Eleven Labs TTS](/docs/voice-agent-tts-models#eleven-labs).
   - Refer to our [supported languages](/docs/models-languages-overview) to ensure you're using the correct model (Nova-2 or Nova-3) for your selected language.
 
 #### `agent.think.context_length`

--- a/fern/docs/configure-voice-agent.mdx
+++ b/fern/docs/configure-voice-agent.mdx
@@ -68,7 +68,6 @@ The `Settings` message is a JSON object that contains the following fields:
 
 * Choose your language setting based on your use case:
   - If you know your input language, specify it directly for the best recognition accuracy.
-  - If you expect multiple languages or are unsure, use `multi` for flexible language support.
   - Refer to our [supported languages](/docs/models-languages-overview) to ensure you're using the correct model (Nova-2 or Nova-3) for your selected language.
 
 #### `agent.think.context_length`

--- a/fern/docs/configure-voice-agent.mdx
+++ b/fern/docs/configure-voice-agent.mdx
@@ -68,6 +68,8 @@ The `Settings` message is a JSON object that contains the following fields:
 
 * Choose your language setting based on your use case:
   - If you know your input language, specify it directly for the best recognition accuracy.
+  - If you expect multiple languages or are unsure, use `multi` for flexible language support.
+  - Currently `multi` is only supported with [Eleven Labs TTS](/docs/voice-agent-tts-models#eleven-labs)
   - Refer to our [supported languages](/docs/models-languages-overview) to ensure you're using the correct model (Nova-2 or Nova-3) for your selected language.
 
 #### `agent.think.context_length`


### PR DESCRIPTION
- relates to https://github.com/orgs/deepgram/discussions/1278 
- multi language is currently disallowed with Deepgram TTS but works with 11 labs only