### PR TITLE
Note expanded languages for numerals, profanity filtering, redaction

### DIFF
--- a/fern/docs/stt-pre-recorded-feature-overview.mdx
+++ b/fern/docs/stt-pre-recorded-feature-overview.mdx
@@ -24,11 +24,11 @@ slug: docs/stt-pre-recorded-feature-overview
 | [Smart Formatting](/docs/smart-format)     | [All available](/docs/models-overview)                              |
 | [Speaker Diarization](/docs/diarization)   | [All available](/docs/models-overview)                              |
 | [Filler words](/docs/filler-words)         | [English (all available regions)](/docs/models-overview)            |
-| [Numerals](/docs/numerals)                 | [English (all available regions)](/docs/models-overview)            |
+| [Numerals](/docs/numerals)                 | [Specific languages only](/docs/models-overview)                    |
 | [Punctuation](/docs/punctuation)           | [All available](/docs/models-overview)                              |
 | [Paragraphs](/docs/paragraphs)             | [All in which words are delimited by spaces](/docs/models-overview) |
-| [Profanity Filter](/docs/profanity-filter) | [English (all available regions)](/docs/models-overview)            |
-| [Redaction](/docs/redaction)               | [English (all available regions)](/docs/models-overview)            |
+| [Profanity Filter](/docs/profanity-filter) | [Specific languages only](/docs/models-overview)                    |
+| [Redaction](/docs/redaction)               | [Specific languages only](/docs/models-overview)                    |
 | [Utterances](/docs/utterances)             | [All available](/docs/models-overview)                              |
 | [Utterance Split](/docs/utterance-split)   | [All available](/docs/models-overview)                              |
 

--- a/fern/docs/stt-streaming-feature-overview.mdx
+++ b/fern/docs/stt-streaming-feature-overview.mdx
@@ -27,10 +27,10 @@ slug: docs/stt-streaming-feature-overview
 | [Smart Formatting](/docs/smart-format)     | [All available](/docs/models-overview)                   |
 | [Speaker Diarization](/docs/diarization)   | [All available](/docs/models-overview)                   |
 | [Filler words](/docs/filler-words)         | [English (all available regions)](/docs/models-overview) |
-| [Numerals](/docs/numerals)                 | [English (all available regions)](/docs/models-overview) |
+| [Numerals](/docs/numerals)                 | [Specific languages only](/docs/models-overview)         |
 | [Punctuation](/docs/punctuation)           | [All available](/docs/models-overview)                   |
-| [Profanity Filter](/docs/profanity-filter) | [English (all available regions)](/docs/models-overview) |
-| [Redaction](/docs/redaction)               | [English (all available regions)](/docs/models-overview) |
+| [Profanity Filter](/docs/profanity-filter) | [Specific languages only](/docs/models-overview)         |
+| [Redaction](/docs/redaction)               | [Specific languages only](/docs/models-overview)         |
 
 ## Custom Vocabulary
 


### PR DESCRIPTION
Account for language expansions on STT feature overview pages:
- [Numerals](https://deepgram.com/changelog/expanded-language-support-for-numerals)
- [Profanity filtering](https://deepgram.com/changelog/expanded-profanity-filtering-and-smart-formatting-improvements)
- Redaction: more complicated, but many languages on hosted, English-only on self-hosted