### PR TITLE
update LLM model availability and pricing tiers

### DIFF
--- a/fern/docs/voice-agent-llm-models.mdx
+++ b/fern/docs/voice-agent-llm-models.mdx
@@ -82,26 +82,25 @@ The `agent.think.endpoint` is optional or required based on the provider type:
 
 ### OpenAI
 
-| Provider                      | Model      | Availability |
+| Provider                      | Model      | Pricing Tier |
 | ------------------------------ | --------- |--------|
-| `open_ai`    | `gpt-4.1` | `Coming Soon!` |
-| `open_ai`    | `gpt-4.1-mini` | `GA` |
-| `open_ai`    | `gpt-4.1-nano` | `GA` |
-| `open_ai`    | `gpt-4o` | `Coming Soon!` |
-| `open_ai`    | `gpt-4o-mini` | `GA` |
+| `open_ai`    | `gpt-4.1` | `Advanced (temporarily available in Standard)` |
+| `open_ai`    | `gpt-4.1-mini` | `Standard` |
+| `open_ai`    | `gpt-4.1-nano` | `Standard` |
+| `open_ai`    | `gpt-4o` | `Advanced (temporarily available in Standard)` |
+| `open_ai`    | `gpt-4o-mini` | `Standard` |
 
 
 ### Anthropic
 
-| Provider                      | Model      | Availability |
+| Provider                      | Model      | Pricing Tier |
 | ------------------------------ | --------- |--------|
-| `anthropic`    | `claude-3-5-haiku-latest` | `GA` |
-| `anthropic`    | `claude-3-haiku-20240307` | `GA` |
-| `anthropic`    | `claude-4-sonnet` | `Coming Soon!` |
+| `anthropic`    | `claude-3-5-haiku-latest` | `Standard` |
+| `anthropic`    | `claude-sonnet-4-20250514` | `Advanced (temporarily available in Standard)` |
 
 ### Google
 
-| Provider                      | Model      | Availability |
+| Provider                      | Model      | Pricing Tier |
 | ------------------------------ | --------- |--------|
 | `google`    | `gemini-2-0-flash` | `Coming Soon!` |
 | `google`    | `gemini-2-0-flash-lite` | `Coming Soon!` |


### PR DESCRIPTION
Update voice agent LLM models documentation to reflect current pricing tiers and availability:

- Change table headers from "Availability" to "Pricing Tier" for clarity
- Update OpenAI models:
  - gpt-4.1: Advanced (temporarily available in Standard)
  - gpt-4.1-mini: Standard
  - gpt-4.1-nano: Standard
  - gpt-4o: Advanced (temporarily available in Standard)
  - gpt-4o-mini: Standard (changed from GA)

- Update Anthropic models:
  - claude-3-5-haiku-latest: Standard
  - claude-sonnet-4-20250514: Advanced (temporarily available in Standard)
  - Remove claude-3-haiku-20240307 (no longer available)

- Add clear indication for Advanced tier models that are temporarily available in Standard tier
- Maintain Google models as "Coming Soon!" status

This update provides users with accurate information about current pricing tiers and temporary promotional availability.
