### PR TITLE
chore: clarifies 413 vs 422 errors

### DIFF
--- a/fern/docs/errors.mdx
+++ b/fern/docs/errors.mdx
@@ -278,12 +278,12 @@ The request body exceeded the 2MB limit, indicating that the payload size is too
 
 ### `413` Input Text Exceeded Character Limit
 
-The text payload contained more than 2400 characters, which is above the character limit for text-to-speech requests.
+The text payload contained more than the maximum number of characters allowed.
 
 ```json
 {
   "err_code": "Payload Too Large",
-  "err_msg": "Input text exceeds maximum character limit of 2400.",
+  "err_msg": "Input text exceeds maximum character limit of [max_characters].",
   "request_id": "[unique_request_id]"
 }
 ```
@@ -308,6 +308,18 @@ The `Content-Type` header in the request is not supported, requiring it to be ei
 {
   "err_code": "UNSUPPORTED_MEDIA_TYPE",
   "err_msg": "`Content-Type` header is not supported. `Content-Type` must be either `text/plain` or `application/json`.",
+  "request_id": "[unique_request_id]"
+}
+```
+
+### `422` Unprocessable Content
+
+The model failed to process the request.
+
+```json
+{
+  "err_code": "UNPROCESSABLE_ENTITY",
+  "err_msg": "Failed to handle request.",
   "request_id": "[unique_request_id]"
 }
 ```

--- a/fern/docs/streaming-text-to-speech.mdx
+++ b/fern/docs/streaming-text-to-speech.mdx
@@ -549,9 +549,14 @@ Keep these limits in mind when making a Deepgram text-to-speech request.
 
 If you are building for conversational AI use cases where a human is talking to a TTS agent, a single websocket per conversation is required. After you establish a connection, you will not be able to change the voice or media output settings.
 
-### Character Limits
+### Input Text Limit
 
-The input limit is currently 2000 characters for the text input of each Speak message. If the string length sent as the text payload is 2001 characters or more, you will receive an error, and the audio file will not be created.
+Sending a request with a text payload longer than the maximum number of characters can result in either a [**422: Unprocessable Content**](/docs/errors#422-unprocessable-content) error or a [**413: Input Text Exceeds Character Limits**](/docs/errors#413-input-text-exceeded-character-limit) error, and the audio file will not be created.
+
+| Model  | Max Characters|
+|--------|---------------|
+| Aura-2 | 1000          |
+| Aura-1 | 2000          |
 
 ### Character Throughput Limits
 

--- a/fern/docs/text-to-speech.mdx
+++ b/fern/docs/text-to-speech.mdx
@@ -390,7 +390,7 @@ Keep these limits in mind when making a Deepgram text-to-speech request.
 
 ### Input Text Limit
 
-Sending a request with a text payload longer than the maximum number of characters will result in a **422: Unprocessable Content** error, and the audio file will not be created.
+Sending a request with a text payload longer than the maximum number of characters can result in either a [**422: Unprocessable Content**](/docs/errors#422-unprocessable-content) error or a [**413: Input Text Exceeds Character Limits**](/docs/errors#413-input-text-exceeded-character-limit) error, and the audio file will not be created.
 
 | Model  | Max Characters|
 |--------|---------------|


### PR DESCRIPTION
- Builds of #283 and explains 413 vs 422 more clearly in Getting TTSStarted Guides
- Adds 422 to Errors page